### PR TITLE
Fix: Display of long container details

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+err_msg="\033[31m> A problem occured during download!\033[0m"
+add_path=false
+version=latest
+
+if [ -n "$1" ]; then
+  version="$1"
+fi
+file_url="https://github.com/scnplt/crabd/releases/download/$version/linux-crabd.tar.gz"
+
+read -p "Do you want to add crabd to /usr/bin/? (y/N): " user_input
+if echo "$user_input" | grep -iq "^[Yy]$"; then
+  add_path=true
+fi
+
+echo "Downloading from $file_url"
+
+if which curl >/dev/null; then
+  if ! curl -fSL "$file_url" -o linux-crabd.tar.gz; then
+    echo "$err_msg"
+    exit 1
+  fi
+elif which wget >/dev/null; then
+  if ! wget "$file_url"; then
+    echo "err_msg"
+    exit 1
+  fi
+else
+  echo 'curl or wget not installed!'
+  exit 1
+fi
+
+tar xzf linux-crabd.tar.gz
+rm linux-crabd.tar.gz
+
+if $add_path; then
+  echo '\033[33m> Adding crabd to /usr/bin/\033[0m'
+  mv crabd /usr/bin && chmod +x /usr/bin/crabd
+fi
+
+echo '\033[32m> Installation complete.\033[0m'

--- a/src/app.rs
+++ b/src/app.rs
@@ -144,7 +144,8 @@ impl App {
 
     fn go_to_info_screen(&mut self) {
         if self.current_screen == CurrentScreen::List {
-            self.current_screen = CurrentScreen::Info
+            self.current_screen = CurrentScreen::Info;
+            self.container_info.reset_scroll_state();
         }
     }
 

--- a/src/views/common.rs
+++ b/src/views/common.rs
@@ -6,13 +6,19 @@ use ratatui::{
     Frame
 };
 
-pub fn render_scrollbar(frame: &mut Frame, area: Rect, state: &mut ScrollbarState, style: Option<Style>) {
-    let scrollbar_style = style.unwrap_or(Style::default().fg(tailwind::BLUE.c900));
-    
-    let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-        .begin_symbol(Some("^"))
-        .end_symbol(Some("v"))
-        .style(scrollbar_style);
+pub fn render_scrollbar(frame: &mut Frame, area: Rect, state: &mut ScrollbarState, is_vertical: bool) {
+    let (orientation, begin_symbol, end_symbol, track_symbol, thumb_symbol) = if is_vertical {
+        (ScrollbarOrientation::VerticalRight, Some("^"), Some("v"), Some("│"), "█")
+    } else {
+        (ScrollbarOrientation::HorizontalBottom, Some("<"), Some(">"), Some("─"), "■")
+    };
+
+    let scrollbar = Scrollbar::new(orientation)
+        .begin_symbol(begin_symbol)
+        .end_symbol(end_symbol)
+        .track_symbol(track_symbol)
+        .thumb_symbol(thumb_symbol)
+        .style(Style::default().fg(tailwind::BLUE.c900));
 
     frame.render_stateful_widget(scrollbar, area, state);
 }

--- a/src/views/container_info.rs
+++ b/src/views/container_info.rs
@@ -57,7 +57,7 @@ impl ContainerInfoData {
             .unwrap_or_else(|| "-".to_string());
         let labels = config
             .and_then(|c| c.labels.as_ref())
-            .map(get_formatted_labels)
+            .map(|l| l.iter().map(|(v, d)| format!("{}: {}", v, d)).collect::<Vec<String>>().join("\n"))
             .unwrap_or_else(|| "-".to_string());
 
         let restart_policies = container.host_config.as_ref()
@@ -101,18 +101,6 @@ impl ContainerInfoData {
             labels,
         }
     }
-}
-
-fn get_formatted_labels(labels: &HashMap<String, String>) -> String {
-    labels.iter()
-        .filter(|line| !is_system_line(line))
-        .map(|(label, value)| format!("{}: {}", label, value))
-        .collect::<Vec<String>>()
-        .join("\n")
-}
-
-fn is_system_line((label, _): &(&String, &String)) -> bool {
-    label.starts_with("org") || label.starts_with("com")
 }
 
 fn get_ports_text(ports: &HashMap<String, Option<Vec<PortBinding>>>) -> String {
@@ -261,7 +249,7 @@ fn get_content_as_lines(data: &ContainerInfoData) -> Vec<Line<'static>> {
     }
 
     if let Some(labels) = get_filtered_list(&data.labels) {
-        lines.extend(vec![spacer.clone(), ("Labels (Some system labels are hidden!):".to_string(), "".to_string())]);
+        lines.extend(vec![spacer.clone(), ("Labels:".to_string(), "".to_string())]);
         lines.extend(labels);
     }
 

--- a/src/views/container_table.rs
+++ b/src/views/container_table.rs
@@ -132,7 +132,7 @@ impl ContainersTable {
             .content_length(content_height)
             .position(self.vertical_scroll);
 
-        render_scrollbar(frame, scrollbar_area, &mut self.scrollbar_state, None);
+        render_scrollbar(frame, scrollbar_area, &mut self.scrollbar_state, true);
 
         let footer_text = get_footer_text(show_all, self.is_selected_container_running());
         render_footer(footer_area, frame.buffer_mut(), footer_text, None, None);


### PR DESCRIPTION
This PR includes the following changes:
- Reverts the commit "[Fix: System labels that are too long break the UI](https://github.com/scnplt/crabd/commit/6e621fa499333f71f43159a274bdcbea1d94d532)" and reinstates the display of the `org` and `com` labels.
- Enhances scrollbar functionality and resets the scroll state when changing screens.
- Removes line wrapping settings.
- Adds a shell script for easier installation: `sudo ./install.sh VERSION_TAG`