### PR TITLE
chore: adopt branching model, contribution guide, and English-only rule

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,50 @@
+# Git Workflow
+
+## Branching Model
+
+| Branch | Role | Merged from |
+|--------|------|-------------|
+| `main` | Production / release. Only released code. | `dev` -> `main` (release PR) or `hotfix/*` -> `main` |
+| `dev` | Integration / development branch. Default base branch. | `feat/*`, `fix/*`, ... -> `dev` PR |
+| `<type>/<slug>` | A single feature or fix. Short-lived. | Deleted after merge |
+
+Rules:
+
+- **Every feature lives on its own branch.** Never commit directly to `dev` or `main`.
+- Feature branches are **cut from `dev`** and return to **`dev`** through a PR:
+  ```bash
+  git checkout dev && git pull
+  git checkout -b feat/<slug>
+  # ... commits ...
+  git push -u origin feat/<slug>
+  gh pr create --base dev
+  ```
+- Branch names reuse the commit types: `feat/`, `fix/`, `refactor/`, `docs/`, `test/`,
+  `chore/`, `perf/`, `ci/`. Example: `feat/image-search`, `fix/empty-list-panic`.
+- **Release:** `dev` -> `main` PR. A merge into `main` means "releasable" and is tagged
+  `vX.Y.Z`.
+- **Hotfix:** only when a release is broken — cut `hotfix/<slug>` from `main`, merge into
+  `main`, then merge `main` back into `dev` so the fix is not lost.
+- Delete merged feature branches locally and on the remote.
+- Treat `main` and `dev` as protected: no force push, no merge without a PR.
+
+## Commit Message Format
+
+```
+<type>: <description>
+
+<optional body explaining why, not what>
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`
+
+## Pull Request Workflow
+
+When creating PRs:
+
+1. Analyze the full commit history of the branch (not just the latest commit)
+2. Use `git diff dev...HEAD` to see all changes
+3. Draft a comprehensive PR summary
+4. Include a test plan
+5. Push with `-u` on the first push of a new branch
+6. A PR that closes an issue carries a bare `Closes #N` line in its body

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,15 @@ TUI app built with ratatui + crossterm, async runtime tokio, Docker API via boll
 
 ## Conventions
 
-- Work on the `dev` branch; PRs target `main`.
+- **Language rule**: everything in this repository is written in English — code, identifiers, comments, documentation, commit messages, issues, PRs, and any other text. (Conversation with the maintainer may be in Turkish, but repository content is always English.)
 - Keep clippy clean (`-D warnings`) and run `cargo fmt` before committing.
 - Source layout: `src/docker/` (Docker/bollard integration), `src/ui/` (ratatui widgets), `src/main.rs` (entry point and event loop).
+
+## Branching
+
+`main` = production/release, `dev` = integration, every feature on its own
+`<type>/<slug>` branch cut from `dev`. Never commit directly to `main` or `dev`.
+Full model: `.claude/rules/git-workflow.md`. Contributor-facing version: `CONTRIBUTING.md`.
 
 ## Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing
+
+Thanks for your interest in crabd! Contributions are welcome. The notes below
+keep the history clean and reviews cheap.
+
+## Before you write code
+
+For anything more than a small fix, open an issue first so the change can be
+discussed before you invest time in it.
+
+## Language
+
+**Everything in this repository is English.** Code comments, doc comments,
+identifiers, log and error messages, markdown, commit messages, branch names,
+PR titles and bodies, issue text. This holds regardless of the language a
+discussion happens in.
+
+## Branching
+
+| Branch | Role |
+|---|---|
+| `main` | Production / release. Tagged `vX.Y.Z`. |
+| `dev` | Integration. The default base for pull requests. |
+| `<type>/<slug>` | One feature or fix. Short-lived, deleted after merge. |
+
+Never commit directly to `main` or `dev`. Cut from `dev`, return to `dev`:
+
+```bash
+git checkout dev && git pull
+git checkout -b feat/my-change
+# ... commits ...
+git push -u origin feat/my-change
+gh pr create --base dev
+```
+
+Branch prefixes reuse the commit types: `feat/`, `fix/`, `refactor/`, `docs/`,
+`test/`, `chore/`, `perf/`, `ci/`.
+
+## Commits
+
+```
+<type>: <description>
+
+<optional body explaining why, not what>
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`.
+
+Keep commits small enough to review on their own. The body is for the reason a
+change is correct — the diff already says what changed.
+
+## Gates
+
+Every one of these must pass before a pull request is ready:
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo build
+cargo test
+```
+
+Testing UI changes also means running the TUI (`cargo run`) against a real
+Docker daemon and exercising the affected screens.
+
+## License
+
+By contributing you agree your work is licensed under the
+[Apache License 2.0](LICENSE.txt), the same as the rest of the project.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ cargo run --release
 
 ## Contributing
 
-Contributions are welcome! Please open issues or pull requests on [GitHub](https://github.com/scnplt/crabd).
+Contributions are welcome! Please open issues or pull requests on [GitHub](https://github.com/scnplt/crabd) and read [CONTRIBUTING.md](./CONTRIBUTING.md) first for the branching model, commit conventions, and checks.
+
+All repository content — code, comments, documentation, commit messages, issues, and pull requests — must be written in English.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Define the git structure for the project: `main` = production/release, `dev` = integration, every change on its own `<type>/<slug>` branch merged back into `dev` via PR.
- Add `CONTRIBUTING.md` with the contributor-facing rules: English-only content, branching model, commit format (`<type>: <description>`), and the Rust gates (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build`, `cargo test`).
- Add `.claude/rules/git-workflow.md` with the full branching/release/hotfix model.
- Update `CLAUDE.md`: replace the old "work on dev, PR to main" line with the new Branching section; record the English-only language rule.
- Link `CONTRIBUTING.md` from the README Contributing section.

## Test plan

- Documentation-only change; verified all internal links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)