### PR TITLE
fix: prevent underflow panic when navigating an empty table

### DIFF
--- a/src/ui/resource_table.rs
+++ b/src/ui/resource_table.rs
@@ -48,14 +48,14 @@ pub trait ResourceTable {
 
     fn next_row(&mut self) {
         let table_info = self.get_table_info();
-        let last_index = table_info.items.len() - 1;
+        let Some(last_index) = table_info.items.len().checked_sub(1) else { return };
         let next_index = table_info.state.selected().map_or(0, |i| if i >= last_index { 0 } else { i + 1 });
         self.select_row(next_index);
     }
 
     fn previous_row(&mut self) {
         let table_info = self.get_table_info();
-        let last_index = table_info.items.len() - 1;
+        let Some(last_index) = table_info.items.len().checked_sub(1) else { return };
         let previous_index = table_info.state.selected().map_or(0, |i| if i == 0 { last_index } else { i - 1 });
         self.select_row(previous_index);
     }


### PR DESCRIPTION
## Summary

`ResourceTable::next_row` and `previous_row` computed `items.len() - 1`, which underflows on `usize` when the table is empty (e.g. the Volumes or Networks tab with no resources), panicking in debug builds and producing an invalid selection in release. Both methods now use `checked_sub(1)` and return early when there are no rows.

Closes #17

## Test plan

- `cargo build` and `cargo test` pass.
- Manual: open a tab with an empty resource list and press `j`/`k` — no panic, selection unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)