### PR TITLE
fix: avoid slice panic in volume-in-use error for short container IDs

### DIFF
--- a/src/ui/volume_table.rs
+++ b/src/ui/volume_table.rs
@@ -127,7 +127,10 @@ impl VolumeTable {
         let err_msg = Regex::new(REGEX_VOLUME_IN_USE).ok()
             .and_then(|re| re.captures(&err))
             .and_then(|caps| caps.get(1))
-            .map(|m| format!("Volume is in use by container: {}...", &m.as_str()[..15]))
+            .map(|m| {
+                let id = m.as_str();
+                format!("Volume is in use by container: {}...", id.get(..15).unwrap_or(id))
+            })
             .unwrap_or_else(|| "Something went wrong...".to_string());
 
         self.err = Some(format!("[ERR] {}", err_msg))


### PR DESCRIPTION
## Summary

`VolumeTable::show_remove_volume_err` truncated the captured container ID with `&m.as_str()[..15]`, which panics with a slice out-of-bounds error when the ID is shorter than 15 characters — crashing the TUI while rendering a user-facing error message. The truncation now uses `get(..15)` and falls back to the full ID when it is shorter.

Closes #18

## Test plan

- `cargo build` and `cargo test` pass.
- Manual: trigger a "volume in use" removal error whose message contains a short container ID — the error renders in the footer instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)