### PR TITLE
fix: resolve collapsible_if clippy errors

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -205,10 +205,10 @@ impl App {
     }
 
     async fn update_container_details(&mut self, container_id: String) -> Result<()> {
-        if let Some(data) = self.get_container_data(container_id).await {
-            if let Some(info_block) = self.container_info.as_mut() {
-                info_block.update_data(data);
-            }
+        if let Some(data) = self.get_container_data(container_id).await
+            && let Some(info_block) = self.container_info.as_mut()
+        {
+            info_block.update_data(data);
         }
         Ok(())
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -78,10 +78,10 @@ impl EventTask {
                 _ = self.sender.closed() => break,
                 _ = tick_delay => self.send(Event::Tick),
                 Some(Ok(event)) = crossterm_event => {
-                    if let Key(key) = event {
-                        if key.kind == KeyEventKind::Press {
-                            self.send(Event::Crossterm(key))
-                        }
+                    if let Key(key) = event
+                        && key.kind == KeyEventKind::Press
+                    {
+                        self.send(Event::Crossterm(key))
                     }
                 }
             };


### PR DESCRIPTION
## Summary

`cargo clippy -- -D warnings` fails on dev with two `collapsible_if` errors introduced by newer clippy (1.96): nested `if let` blocks in `App::update_container_details` (src/app.rs) and the crossterm event loop (src/event.rs). Both are collapsed into let chains; behavior is unchanged.

## Test plan

- `cargo clippy -- -D warnings` passes.
- `cargo build` and `cargo test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)