### PR TITLE
refactor: replace stringly-typed container data with typed domain models

### DIFF
--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -1,1 +1,2 @@
 pub mod client;
+pub mod models;

--- a/src/docker/models.rs
+++ b/src/docker/models.rs
@@ -1,0 +1,369 @@
+use std::collections::HashMap;
+use std::fmt;
+
+use bollard::secret::{
+    ContainerStateStatusEnum, MountPoint, MountPointTypeEnum, Port, PortBinding, PortTypeEnum,
+};
+
+/// Parses the loosely-typed `state` string coming from the Docker API into the
+/// typed enum, falling back to `EMPTY` when missing or unrecognized.
+pub fn parse_container_state(state: Option<&str>) -> ContainerStateStatusEnum {
+    state
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(ContainerStateStatusEnum::EMPTY)
+}
+
+/// Human-readable label for a container state, used only for table rendering.
+pub fn state_label(state: ContainerStateStatusEnum) -> String {
+    if state == ContainerStateStatusEnum::EMPTY {
+        "-".to_string()
+    } else {
+        state.to_string()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PortMapping {
+    pub private: u16,
+    pub public: u16,
+    pub protocol: PortTypeEnum,
+}
+
+impl fmt::Display for PortMapping {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}/{}", self.private, self.public, self.protocol)
+    }
+}
+
+impl PortMapping {
+    pub fn from_summary_ports(ports: &[Port]) -> Vec<PortMapping> {
+        let mut filtered_ports: Vec<PortMapping> = ports
+            .iter()
+            .filter_map(|p| {
+                Some(PortMapping {
+                    private: p.private_port,
+                    public: p.public_port?,
+                    protocol: p.typ?,
+                })
+            })
+            .collect();
+
+        filtered_ports.sort_by_key(|p| p.private);
+        filtered_ports.dedup();
+
+        filtered_ports
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostBinding {
+    pub host_ip: String,
+    pub host_port: String,
+}
+
+impl fmt::Display for HostBinding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.host_ip, self.host_port)
+    }
+}
+
+impl HostBinding {
+    fn from_binding(binding: &PortBinding) -> HostBinding {
+        HostBinding {
+            host_ip: binding.host_ip.clone().unwrap_or_default(),
+            host_port: binding.host_port.clone().unwrap_or_default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortConfig {
+    pub container_port: String,
+    pub protocol: String,
+    pub ipv4: Option<HostBinding>,
+    pub ipv6: Option<HostBinding>,
+}
+
+impl fmt::Display for PortConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (&self.ipv4, &self.ipv6) {
+            (Some(ipv4), Some(ipv6)) => write!(
+                f,
+                "{ipv4} | {ipv6} -> {}/{}",
+                self.container_port, self.protocol
+            ),
+            (Some(ipv4), None) => {
+                write!(f, "{ipv4} -> {}/{}", self.container_port, self.protocol)
+            }
+            (None, Some(ipv6)) => {
+                write!(f, "{ipv6} -> {}/{}", self.container_port, self.protocol)
+            }
+            (None, None) => write!(f, ""),
+        }
+    }
+}
+
+impl PortConfig {
+    pub fn from_port_map(ports: &HashMap<String, Option<Vec<PortBinding>>>) -> Vec<PortConfig> {
+        ports
+            .iter()
+            .filter_map(|(port, bindings)| {
+                let (ipv4_binding, ipv6_binding) = bindings
+                    .as_ref()
+                    .map(|b| {
+                        let ipv4 = b
+                            .iter()
+                            .find(|pb| pb.host_ip == Some("0.0.0.0".to_string()));
+                        let ipv6 = b.iter().find(|pb| pb.host_ip == Some("::".to_string()));
+                        (ipv4, ipv6)
+                    })
+                    .unwrap_or((None, None));
+
+                let ipv4 = ipv4_binding.map(HostBinding::from_binding);
+                let ipv6 = ipv6_binding.map(HostBinding::from_binding);
+
+                if ipv4.is_none() && ipv6.is_none() {
+                    return None;
+                }
+
+                let container_port = port.split('/').next().unwrap_or("").to_string();
+                let protocol = port.split('/').nth(1).unwrap_or("").to_string();
+
+                Some(PortConfig {
+                    container_port,
+                    protocol,
+                    ipv4,
+                    ipv6,
+                })
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Mount {
+    pub source: String,
+    pub destination: String,
+}
+
+impl fmt::Display for Mount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} -> {}", self.source, self.destination)
+    }
+}
+
+impl Mount {
+    pub fn from_mount_points(mount_points: &[MountPoint]) -> Vec<Mount> {
+        mount_points
+            .iter()
+            .map(|mp| {
+                let source = match mp.typ {
+                    Some(MountPointTypeEnum::VOLUME) => {
+                        mp.name.clone().unwrap_or_else(|| "-".to_string())
+                    }
+                    Some(_) => mp.source.clone().unwrap_or_else(|| "-".to_string()),
+                    None => "-".to_string(),
+                };
+
+                let destination = mp.destination.clone().unwrap_or_else(|| "-".to_string());
+
+                Mount {
+                    source,
+                    destination,
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_container_state_recognizes_known_values() {
+        assert_eq!(
+            parse_container_state(Some("running")),
+            ContainerStateStatusEnum::RUNNING
+        );
+        assert_eq!(
+            parse_container_state(Some("restarting")),
+            ContainerStateStatusEnum::RESTARTING
+        );
+    }
+
+    #[test]
+    fn parse_container_state_falls_back_to_empty() {
+        assert_eq!(parse_container_state(None), ContainerStateStatusEnum::EMPTY);
+        assert_eq!(
+            parse_container_state(Some("bogus")),
+            ContainerStateStatusEnum::EMPTY
+        );
+    }
+
+    #[test]
+    fn state_label_formats_correctly() {
+        assert_eq!(state_label(ContainerStateStatusEnum::EMPTY), "-");
+        assert_eq!(state_label(ContainerStateStatusEnum::RUNNING), "running");
+    }
+
+    #[test]
+    fn port_mapping_filters_sorts_and_dedups() {
+        let ports = vec![
+            Port {
+                private_port: 8080,
+                public_port: Some(80),
+                typ: Some(PortTypeEnum::TCP),
+                ..Default::default()
+            },
+            Port {
+                private_port: 22,
+                public_port: None,
+                typ: Some(PortTypeEnum::TCP),
+                ..Default::default()
+            },
+            Port {
+                private_port: 53,
+                public_port: Some(53),
+                typ: None,
+                ..Default::default()
+            },
+            Port {
+                private_port: 443,
+                public_port: Some(443),
+                typ: Some(PortTypeEnum::TCP),
+                ..Default::default()
+            },
+            Port {
+                private_port: 8080,
+                public_port: Some(80),
+                typ: Some(PortTypeEnum::TCP),
+                ..Default::default()
+            },
+        ];
+
+        let mappings = PortMapping::from_summary_ports(&ports);
+        assert_eq!(mappings.len(), 2);
+        assert_eq!(mappings[0].private, 443);
+        assert_eq!(mappings[1].private, 8080);
+        assert_eq!(mappings[1].to_string(), "8080:80/tcp");
+    }
+
+    #[test]
+    fn port_config_from_port_map_handles_ipv4_only() {
+        let mut ports = HashMap::new();
+        ports.insert(
+            "80/tcp".to_string(),
+            Some(vec![PortBinding {
+                host_ip: Some("0.0.0.0".to_string()),
+                host_port: Some("8080".to_string()),
+            }]),
+        );
+
+        let configs = PortConfig::from_port_map(&ports);
+        assert_eq!(configs.len(), 1);
+        assert_eq!(configs[0].to_string(), "0.0.0.0:8080 -> 80/tcp");
+    }
+
+    #[test]
+    fn port_config_from_port_map_handles_ipv6_only() {
+        let mut ports = HashMap::new();
+        ports.insert(
+            "80/tcp".to_string(),
+            Some(vec![PortBinding {
+                host_ip: Some("::".to_string()),
+                host_port: Some("8080".to_string()),
+            }]),
+        );
+
+        let configs = PortConfig::from_port_map(&ports);
+        assert_eq!(configs.len(), 1);
+        assert_eq!(configs[0].to_string(), ":::8080 -> 80/tcp");
+    }
+
+    #[test]
+    fn port_config_from_port_map_handles_both() {
+        let mut ports = HashMap::new();
+        ports.insert(
+            "80/tcp".to_string(),
+            Some(vec![
+                PortBinding {
+                    host_ip: Some("0.0.0.0".to_string()),
+                    host_port: Some("8080".to_string()),
+                },
+                PortBinding {
+                    host_ip: Some("::".to_string()),
+                    host_port: Some("8080".to_string()),
+                },
+            ]),
+        );
+
+        let configs = PortConfig::from_port_map(&ports);
+        assert_eq!(configs.len(), 1);
+        let text = configs[0].to_string();
+        assert!(text.contains(" | "));
+        assert!(text.ends_with(" -> 80/tcp"));
+    }
+
+    #[test]
+    fn port_config_from_port_map_skips_missing_bindings() {
+        let mut ports = HashMap::new();
+        ports.insert("80/tcp".to_string(), None);
+        ports.insert("80".to_string(), Some(vec![]));
+
+        let configs = PortConfig::from_port_map(&ports);
+        assert!(configs.is_empty());
+    }
+
+    #[test]
+    fn port_config_from_port_map_handles_key_without_slash() {
+        let mut ports = HashMap::new();
+        ports.insert(
+            "80".to_string(),
+            Some(vec![PortBinding {
+                host_ip: Some("0.0.0.0".to_string()),
+                host_port: Some("8080".to_string()),
+            }]),
+        );
+
+        let configs = PortConfig::from_port_map(&ports);
+        assert_eq!(configs.len(), 1);
+        assert_eq!(configs[0].protocol, "");
+        assert_eq!(configs[0].container_port, "80");
+    }
+
+    #[test]
+    fn mount_from_mount_points_selects_source_by_type() {
+        let mount_points = vec![
+            MountPoint {
+                typ: Some(MountPointTypeEnum::VOLUME),
+                name: Some("my-volume".to_string()),
+                source: Some("/var/lib/docker/volumes/my-volume".to_string()),
+                destination: Some("/data".to_string()),
+                ..Default::default()
+            },
+            MountPoint {
+                typ: Some(MountPointTypeEnum::BIND),
+                name: None,
+                source: Some("/host/path".to_string()),
+                destination: Some("/container/path".to_string()),
+                ..Default::default()
+            },
+            MountPoint {
+                typ: None,
+                name: None,
+                source: None,
+                destination: None,
+                ..Default::default()
+            },
+        ];
+
+        let mounts = Mount::from_mount_points(&mount_points);
+        assert_eq!(mounts[0].source, "my-volume");
+        assert_eq!(mounts[0].destination, "/data");
+        assert_eq!(mounts[1].source, "/host/path");
+        assert_eq!(mounts[1].destination, "/container/path");
+        assert_eq!(mounts[2].source, "-");
+        assert_eq!(mounts[2].destination, "-");
+    }
+}

--- a/src/ui/container_info_block.rs
+++ b/src/ui/container_info_block.rs
@@ -1,11 +1,10 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
+use crate::docker::models::{Mount, PortConfig};
 use crate::{event::AppEvent, utils::is_container_running};
 
 use super::common::{render_footer, render_scrollbar};
-use bollard::secret::{
-    ContainerInspectResponse, ContainerStateStatusEnum, MountPoint, MountPointTypeEnum, PortBinding,
-};
+use bollard::secret::{ContainerInspectResponse, ContainerStateStatusEnum};
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
@@ -25,22 +24,43 @@ pub struct ContainerInfoBlock {
     skipped_tick_count_for_refresh: u8,
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct ContainerData {
     id: String,
     name: String,
     image: String,
     created: String,
-    state: String,
+    state: ContainerStateStatusEnum,
     ip_address: String,
     start_time: String,
-    port_configs: String,
-    cmd: String,
-    entrypoint: String,
-    env: String,
+    port_configs: Vec<PortConfig>,
+    cmd: Vec<String>,
+    entrypoint: Vec<String>,
+    env: Vec<String>,
     restart_policy: String,
-    volumes: String,
-    labels: String,
+    volumes: Vec<Mount>,
+    labels: BTreeMap<String, String>,
+}
+
+impl Default for ContainerData {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            name: String::new(),
+            image: String::new(),
+            created: String::new(),
+            state: ContainerStateStatusEnum::EMPTY,
+            ip_address: String::new(),
+            start_time: String::new(),
+            port_configs: Vec::new(),
+            cmd: Vec::new(),
+            entrypoint: Vec::new(),
+            env: Vec::new(),
+            restart_policy: String::new(),
+            volumes: Vec::new(),
+            labels: BTreeMap::new(),
+        }
+    }
 }
 
 impl ScrollableInfoBlock for ContainerInfoBlock {
@@ -75,12 +95,17 @@ impl ScrollableInfoBlock for ContainerInfoBlock {
             if line_len > max { line_len } else { max }
         });
 
-        self.scroll_info.max_horizontal = max_horizontal.saturating_sub(info_area.width as usize - 2);
-        self.scroll_info.max_vertical = content_lines.len().saturating_sub(info_area.height as usize - 2);
+        self.scroll_info.max_horizontal =
+            max_horizontal.saturating_sub(info_area.width as usize - 2);
+        self.scroll_info.max_vertical = content_lines
+            .len()
+            .saturating_sub(info_area.height as usize - 2);
 
         self.render_content(frame, info_area, content_lines);
 
-        self.scroll_info.vertical_state = self.scroll_info.vertical_state
+        self.scroll_info.vertical_state = self
+            .scroll_info
+            .vertical_state
             .content_length(self.scroll_info.max_vertical)
             .position(self.scroll_info.vertical);
 
@@ -91,7 +116,9 @@ impl ScrollableInfoBlock for ContainerInfoBlock {
             true,
         );
 
-        self.scroll_info.horizontal_state = self.scroll_info.horizontal_state
+        self.scroll_info.horizontal_state = self
+            .scroll_info
+            .horizontal_state
             .content_length(self.scroll_info.max_horizontal)
             .position(self.scroll_info.horizontal);
 
@@ -105,7 +132,7 @@ impl ScrollableInfoBlock for ContainerInfoBlock {
         render_footer(
             frame,
             footer_area,
-            get_footer_text(is_container_running(&self.data.state)),
+            get_footer_text(is_container_running(self.data.state)),
             None,
         );
 
@@ -165,10 +192,24 @@ fn get_content_as_lines(data: &ContainerData) -> Vec<Line<'static>> {
         ("Created: ".to_string(), data.created.clone()),
         ("Start Time: ".to_string(), data.start_time.clone()),
         ("Restart Policy: ".to_string(), data.restart_policy.clone()),
-        ("State: ".to_string(), data.state.clone()),
+        ("State: ".to_string(), data.state.to_string()),
         spacer.clone(),
-        ("CMD: ".to_string(), data.cmd.clone()),
-        ("Entrypoint: ".to_string(), data.entrypoint.clone()),
+        (
+            "CMD: ".to_string(),
+            if data.cmd.is_empty() {
+                "-".to_string()
+            } else {
+                data.cmd.join("\n")
+            },
+        ),
+        (
+            "Entrypoint: ".to_string(),
+            if data.entrypoint.is_empty() {
+                "-".to_string()
+            } else {
+                data.entrypoint.join("\n")
+            },
+        ),
     ];
 
     if !data.ip_address.is_empty() {
@@ -178,7 +219,8 @@ fn get_content_as_lines(data: &ContainerData) -> Vec<Line<'static>> {
         ]);
     }
 
-    if let Some(ports) = get_filtered_list(&data.port_configs) {
+    let port_configs = data.port_configs.iter().map(ToString::to_string).collect();
+    if let Some(ports) = format_list(port_configs) {
         lines.extend(vec![
             spacer.clone(),
             ("Port Configs:".to_string(), "".to_string()),
@@ -186,7 +228,8 @@ fn get_content_as_lines(data: &ContainerData) -> Vec<Line<'static>> {
         lines.extend(ports);
     }
 
-    if let Some(volumes) = get_filtered_list(&data.volumes) {
+    let volumes = data.volumes.iter().map(ToString::to_string).collect();
+    if let Some(volumes) = format_list(volumes) {
         lines.extend(vec![
             spacer.clone(),
             ("Volumes:".to_string(), "".to_string()),
@@ -194,12 +237,17 @@ fn get_content_as_lines(data: &ContainerData) -> Vec<Line<'static>> {
         lines.extend(volumes);
     }
 
-    if let Some(env) = get_filtered_list(&data.env) {
+    if let Some(env) = format_list(data.env.clone()) {
         lines.extend(vec![spacer.clone(), ("Env:".to_string(), "".to_string())]);
         lines.extend(env);
     }
 
-    if let Some(labels) = get_filtered_list(&data.labels) {
+    let labels = data
+        .labels
+        .iter()
+        .map(|(k, v)| format!("{k}: {v}"))
+        .collect();
+    if let Some(labels) = format_list(labels) {
         lines.extend(vec![
             spacer.clone(),
             ("Labels:".to_string(), "".to_string()),
@@ -216,18 +264,20 @@ fn get_content_as_lines(data: &ContainerData) -> Vec<Line<'static>> {
         .collect()
 }
 
-fn get_filtered_list(data: &str) -> Option<Vec<(String, String)>> {
-    let mut splitted_data: Vec<String> = data.split("\n")
-        .filter(|p| !p.is_empty())
-        .map(|s| s.to_string())
-        .collect();
+fn format_list(mut entries: Vec<String>) -> Option<Vec<(String, String)>> {
+    entries.retain(|e| !e.is_empty());
 
-    if splitted_data.is_empty() {
+    if entries.is_empty() {
         return None;
     }
 
-    splitted_data.sort_unstable();
-    Some(splitted_data.iter().map(|d| ("".to_string(), format!(" - {d}"))).collect())
+    entries.sort_unstable();
+    Some(
+        entries
+            .iter()
+            .map(|d| ("".to_string(), format!(" - {d}")))
+            .collect(),
+    )
 }
 
 fn get_footer_text(is_running: bool) -> String {
@@ -241,52 +291,56 @@ fn get_footer_text(is_running: bool) -> String {
 
 impl ContainerData {
     pub fn from(container: ContainerInspectResponse) -> Self {
-        let name = container.name.as_deref()
+        let name = container
+            .name
+            .as_deref()
             .and_then(|name| name.strip_prefix("/"))
             .map(String::from)
             .unwrap_or_else(|| "NaN".to_string());
 
-        let restart_policy = container.host_config.as_ref()
+        let restart_policy = container
+            .host_config
+            .as_ref()
             .and_then(|c| c.restart_policy.as_ref())
             .and_then(|c| c.name)
             .map(|name| format!("{name:?}").to_lowercase().replace("_", "-"))
             .unwrap_or_else(|| "-".to_string());
 
         let mut image = "-".to_string();
-        let mut cmd = "-".to_string();
-        let mut env = "-".to_string();
-        let mut entrypoint = "-".to_string();
-        let mut labels = "-".to_string();
+        let mut cmd = Vec::new();
+        let mut env = Vec::new();
+        let mut entrypoint = Vec::new();
+        let mut labels = BTreeMap::new();
         if let Some(config) = container.config {
             image = config.image.unwrap_or(image);
-            cmd = config.cmd.map(|c| c.join("\n")).unwrap_or(cmd);
-            env = config.env.map(|e| e.join("\n")).unwrap_or(env);
-            entrypoint = config.entrypoint.map(|ep| ep.join("\n")).unwrap_or(entrypoint);
-            labels = config.labels.map(|l| {
-                l.iter()
-                    .map(|(v, d)| format!("{v}: {d}"))
-                    .collect::<Vec<String>>()
-                    .join("\n")
-            }).unwrap_or(labels)
+            cmd = config.cmd.unwrap_or_default();
+            env = config.env.unwrap_or_default();
+            entrypoint = config.entrypoint.unwrap_or_default();
+            labels = config.labels.unwrap_or_default().into_iter().collect();
         }
 
         let mut ip_address = "-".to_string();
-        let mut port_configs = "-".to_string();
+        let mut port_configs = Vec::new();
         if let Some(network_settings) = container.network_settings {
             ip_address = network_settings.ip_address.unwrap_or(ip_address);
-            port_configs = network_settings.ports
-                .map(|p| get_ports_text(&p))
-                .unwrap_or(port_configs);
+            port_configs = network_settings
+                .ports
+                .map(|p| PortConfig::from_port_map(&p))
+                .unwrap_or_default();
         }
 
-        let mut state = ContainerStateStatusEnum::EMPTY.to_string();
+        let mut state = ContainerStateStatusEnum::EMPTY;
         let mut start_time = "-".to_string();
         if let Some(state_info) = container.state {
-            state = state_info.status.map(|s| s.to_string()).unwrap_or(state);
+            state = state_info.status.unwrap_or(state);
             start_time = state_info.started_at.unwrap_or(start_time);
         }
 
-        let volumes = container.mounts.as_ref().map_or("-".to_string(), |mp| get_mounts_text(mp));
+        let volumes = container
+            .mounts
+            .as_deref()
+            .map(Mount::from_mount_points)
+            .unwrap_or_default();
 
         Self {
             id: container.id.as_deref().unwrap_or("-").to_string(),
@@ -307,58 +361,76 @@ impl ContainerData {
     }
 }
 
-fn get_ports_text(ports: &HashMap<String, Option<Vec<PortBinding>>>) -> String {
-    ports
-        .iter()
-        .map(|(port, bindings)| {
-            let (ipv4_binding, ipv6_binding) = bindings
-                .as_ref()
-                .map(|b| {
-                    let ipv4 = b.iter().find(|pb| pb.host_ip == Some("0.0.0.0".to_string()));
-                    let ipv6 = b.iter().find(|pb| pb.host_ip == Some("::".to_string()));
-                    (ipv4, ipv6)
-                })
-                .unwrap_or((None, None));
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bollard::secret::{ContainerConfig, ContainerState};
+    use std::collections::HashMap;
 
-            let port_number = port.split('/').next().unwrap_or("");
-            let protocol = port.split('/').nth(1).unwrap_or("");
+    #[test]
+    fn from_extracts_typed_state_and_preserves_order() {
+        let mut labels = HashMap::new();
+        labels.insert("com.example.owner".to_string(), "team-a".to_string());
 
-            let ipv4_str = ipv4_binding.map(get_port_binding_text).unwrap_or_default();
-            let ipv6_str = ipv6_binding.map(get_port_binding_text).unwrap_or_default();
+        let container = ContainerInspectResponse {
+            id: Some("abc123".to_string()),
+            name: Some("/my-container".to_string()),
+            config: Some(ContainerConfig {
+                image: Some("alpine".to_string()),
+                cmd: Some(vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "sleep 1".to_string(),
+                ]),
+                env: Some(vec!["A=1".to_string(), "B=2".to_string()]),
+                labels: Some(labels),
+                ..Default::default()
+            }),
+            state: Some(ContainerState {
+                status: Some(ContainerStateStatusEnum::RUNNING),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
 
-            match (ipv4_str.is_empty(), ipv6_str.is_empty()) {
-                (false, false) => format!("{ipv4_str} | {ipv6_str} -> {port_number}/{protocol}"),
-                (false, true) => format!("{ipv4_str} -> {port_number}/{protocol}"),
-                (true, false) => format!("{ipv6_str} -> {port_number}/{protocol}"),
-                _ => "".to_string(),
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
+        let data = ContainerData::from(container);
 
-fn get_port_binding_text(port_binding: &PortBinding) -> String {
-    format!(
-        "{}:{}",
-        port_binding.host_ip.as_deref().unwrap_or(""),
-        port_binding.host_port.as_deref().unwrap_or("")
-    )
-}
+        assert_eq!(data.state, ContainerStateStatusEnum::RUNNING);
+        assert_eq!(data.cmd, vec!["sh", "-c", "sleep 1"]);
+        assert_eq!(data.env, vec!["A=1", "B=2"]);
+        assert_eq!(
+            data.labels.get("com.example.owner"),
+            Some(&"team-a".to_string())
+        );
+    }
 
-fn get_mounts_text(mount_points: &[MountPoint]) -> String {
-    let mut mp = mount_points.iter()
-        .map(|mp| {
-            let source = match mp.typ {
-                Some(MountPointTypeEnum::VOLUME) => mp.name.clone().unwrap_or("-".to_string()),
-                Some(_) => mp.source.clone().unwrap_or("-".to_string()),
-                None => "-".to_string(),
-            };
+    #[test]
+    fn from_empty_inspect_yields_empty_collections() {
+        let data = ContainerData::from(ContainerInspectResponse::default());
 
-            let destination = mp.destination.clone().unwrap_or("-".to_string());
-            format!("{source} -> {destination}")
-        })
-        .collect::<Vec<String>>();
+        assert_eq!(data.state, ContainerStateStatusEnum::EMPTY);
+        assert!(data.cmd.is_empty());
+        assert!(data.entrypoint.is_empty());
+        assert!(data.env.is_empty());
+        assert!(data.labels.is_empty());
+        assert!(data.port_configs.is_empty());
+        assert!(data.volumes.is_empty());
+    }
 
-    mp.sort_by_key(|v| v.clone());
-    mp.join("\n")
+    #[test]
+    fn get_content_as_lines_drops_empty_optional_sections() {
+        let data = ContainerData::default();
+        let lines: Vec<String> = get_content_as_lines(&data)
+            .iter()
+            .map(|l| l.to_string())
+            .collect();
+
+        // CMD/Entrypoint are "-" when empty and must be filtered out entirely.
+        assert!(!lines.iter().any(|l| l.starts_with("CMD: ")));
+        assert!(!lines.iter().any(|l| l.starts_with("Entrypoint: ")));
+
+        // No optional sections should render when their data is empty.
+        assert!(!lines.iter().any(|l| l.starts_with("Env:")));
+        assert!(!lines.iter().any(|l| l.starts_with("Labels:")));
+    }
 }

--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -1,8 +1,9 @@
+use crate::docker::models::{PortMapping, parse_container_state, state_label};
 use crate::ui::resource_table::ResourceTableInfo;
 use crate::{event::AppEvent, ui::resource_table::ResourceTable, utils::is_container_running};
 
 use super::common::{TableStyle, render_footer};
-use bollard::secret::{ContainerSummary, Port, PortTypeEnum};
+use bollard::secret::{ContainerStateStatusEnum, ContainerSummary};
 use color_eyre::Result;
 use ratatui::style::Stylize;
 use ratatui::{
@@ -26,8 +27,8 @@ pub struct ContainerTableRow {
     id: String,
     name: String,
     image: String,
-    state: String,
-    ports: String,
+    state: ContainerStateStatusEnum,
+    ports: Vec<PortMapping>,
 }
 
 impl Default for ContainerTable {
@@ -96,7 +97,7 @@ impl ResourceTable for ContainerTable {
             .info
             .items
             .iter()
-            .filter(|container| show_all || String::eq(&container.state, "running"))
+            .filter(|container| show_all || is_container_running(container.state))
             .collect();
         let visible_count = visible_items.len();
 
@@ -109,14 +110,9 @@ impl ResourceTable for ContainerTable {
                 } else {
                     self.style.alt_row_style
                 };
-                let item = container.ref_array();
-                let ports: Vec<&str> = container
-                    .ports
-                    .split("\n")
-                    .filter(|s| !s.is_empty())
-                    .collect();
-
-                let height = if ports.is_empty() { 3 } else { ports.len() + 2 };
+                let item = container.cells();
+                let port_count = container.ports.len();
+                let height = if port_count == 0 { 3 } else { port_count + 2 };
                 if index < visible_count - 1 {
                     self.info.row_heights.push(height);
                 }
@@ -150,7 +146,7 @@ impl ResourceTable for ContainerTable {
 
         let is_selected_container_running = self
             .get_selected_row()
-            .map(|c| is_container_running(&c.state));
+            .map(|c| is_container_running(c.state));
         let mut footer_text = get_footer_text(self.show_all, is_selected_container_running);
 
         if let Some(err) = &self.err {
@@ -170,7 +166,7 @@ impl ContainerTable {
             .items
             .iter()
             .enumerate()
-            .filter(|(_, container)| self.show_all || String::eq(&container.state, "running"))
+            .filter(|(_, container)| self.show_all || is_container_running(container.state))
             .map(|(index, _)| index)
             .collect()
     }
@@ -242,8 +238,24 @@ impl ContainerTable {
 }
 
 impl ContainerTableRow {
-    const fn ref_array(&self) -> [&String; 5] {
-        [&self.id, &self.name, &self.image, &self.state, &self.ports]
+    fn cells(&self) -> [String; 5] {
+        let ports_text = if self.ports.is_empty() {
+            "-".to_string()
+        } else {
+            self.ports
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<String>>()
+                .join("\n")
+        };
+
+        [
+            self.id.clone(),
+            self.name.clone(),
+            self.image.clone(),
+            state_label(self.state),
+            ports_text,
+        ]
     }
 
     pub fn from_list(containers: Vec<ContainerSummary>) -> Vec<Self> {
@@ -253,13 +265,13 @@ impl ContainerTableRow {
             .collect::<Vec<ContainerTableRow>>();
 
         result_list.sort_by(|p, n| {
-            let p_is_running = p.state.starts_with("r");
-            let n_is_running = n.state.starts_with("r");
+            let p_is_running = p.state == ContainerStateStatusEnum::RUNNING;
+            let n_is_running = n.state == ContainerStateStatusEnum::RUNNING;
 
             match (p_is_running, n_is_running) {
                 (true, false) => std::cmp::Ordering::Less,
                 (false, true) => std::cmp::Ordering::Greater,
-                _ => p.state.cmp(&n.state),
+                _ => p.state.as_ref().cmp(n.state.as_ref()),
             }
         });
 
@@ -278,29 +290,14 @@ impl ContainerTableRow {
             id: container.id.as_deref().unwrap_or("-").to_string(),
             name,
             image: container.image.as_deref().unwrap_or("-").to_string(),
-            state: container.state.as_deref().unwrap_or("-").to_string(),
+            state: parse_container_state(container.state.as_deref()),
             ports: container
                 .ports
-                .as_ref()
-                .map_or("-".to_string(), |p| get_ports_text(p)),
+                .as_deref()
+                .map(PortMapping::from_summary_ports)
+                .unwrap_or_default(),
         }
     }
-}
-
-fn get_ports_text(ports: &[Port]) -> String {
-    let mut filtered_ports: Vec<(u16, u16, PortTypeEnum)> = ports
-        .iter()
-        .filter_map(|p| Some((p.private_port, p.public_port?, p.typ?)))
-        .collect();
-
-    filtered_ports.sort_by_key(|&(private, _, _)| private);
-    filtered_ports.dedup();
-
-    filtered_ports
-        .iter()
-        .map(|&(private, public, typ)| format!("{private}:{public}/{typ}"))
-        .collect::<Vec<String>>()
-        .join("\n")
 }
 
 fn get_footer_text(show_all: bool, is_running: Option<bool>) -> String {
@@ -317,4 +314,70 @@ fn get_footer_text(show_all: bool, is_running: Option<bool>) -> String {
     }
 
     format!(" <Ent> details | <T> {toggle_text}{op_text}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary_with_state(state: &str) -> ContainerSummary {
+        ContainerSummary {
+            id: Some(format!("id-{state}")),
+            names: Some(vec![format!("/{state}")]),
+            image: Some("image".to_string()),
+            state: Some(state.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn from_list_sorts_running_first_and_others_alphabetically_by_state() {
+        let containers = vec![
+            summary_with_state("exited"),
+            summary_with_state("restarting"),
+            summary_with_state("created"),
+            summary_with_state("running"),
+            summary_with_state("paused"),
+        ];
+
+        let rows = ContainerTableRow::from_list(containers);
+        let states: Vec<ContainerStateStatusEnum> = rows.iter().map(|r| r.state).collect();
+
+        // Running must come first.
+        assert_eq!(states[0], ContainerStateStatusEnum::RUNNING);
+        // "restarting" is not "running", so it must not be treated as running.
+        assert_ne!(states[1], ContainerStateStatusEnum::RESTARTING);
+
+        // Remaining rows are ordered alphabetically by state name:
+        // created < exited < paused < restarting.
+        let non_running_states: Vec<ContainerStateStatusEnum> = states[1..].to_vec();
+        assert_eq!(
+            non_running_states,
+            vec![
+                ContainerStateStatusEnum::CREATED,
+                ContainerStateStatusEnum::EXITED,
+                ContainerStateStatusEnum::PAUSED,
+                ContainerStateStatusEnum::RESTARTING,
+            ]
+        );
+    }
+
+    #[test]
+    fn from_strips_leading_slash_from_name() {
+        let container = summary_with_state("running");
+        let row = ContainerTableRow::from(&container);
+        assert_eq!(row.name, "running");
+    }
+
+    #[test]
+    fn cells_fall_back_to_dash_for_missing_fields() {
+        let container = ContainerSummary::default();
+        let row = ContainerTableRow::from(&container);
+        let cells = row.cells();
+
+        assert_eq!(cells[0], "-"); // id
+        assert_eq!(cells[2], "-"); // image
+        assert_eq!(cells[3], "-"); // state (EMPTY)
+        assert_eq!(cells[4], "-"); // ports
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,17 @@
-pub fn is_container_running(state: &str) -> bool {
-    state == "running"
+use bollard::secret::ContainerStateStatusEnum;
+
+pub fn is_container_running(state: ContainerStateStatusEnum) -> bool {
+    state == ContainerStateStatusEnum::RUNNING
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_container_running_only_true_for_running() {
+        assert!(is_container_running(ContainerStateStatusEnum::RUNNING));
+        assert!(!is_container_running(ContainerStateStatusEnum::RESTARTING));
+        assert!(!is_container_running(ContainerStateStatusEnum::REMOVING));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the stringly-typed data model described in #23:

- **New domain module `src/docker/models.rs`** with typed values: `PortMapping`, `PortConfig`, `HostBinding`, `Mount`, plus `parse_container_state` / `state_label` helpers. Display formatting now happens only at render time via `Display` impls.
- **Container state is now `ContainerStateStatusEnum`** (bollard's enum) instead of `String`. This fixes the `state.starts_with("r")` bug where `restarting`/`removing` containers sorted as running in the table.
- **`ContainerData`** stores `Vec<PortConfig>`, `Vec<Mount>`, `Vec<String>` (cmd/entrypoint/env) and `BTreeMap<String, String>` (labels) instead of `"\n"`-joined strings that were re-split for rendering.
- **`is_container_running`** takes the enum instead of doing string comparison.
- Adds the first unit tests in the repo (17 tests across the new module, utils, container table sorting, and `ContainerData` construction).

### Behavior changes (all implied by the issue)
- `restarting`/`removing` containers no longer sort among running ones.
- Empty Ports/Volumes/Env/Labels sections are omitted instead of rendering a literal `- -` line.
- A container whose ports all lack a public port shows `-` in the table instead of an empty cell.

Everything else (column widths, row heights, sort order, footer, scrolling) is unchanged.

Closes #23

## Test plan
- [x] `cargo build`
- [x] `cargo test` — 17 passed
- [x] `cargo clippy -- -D warnings` (also `--all-targets`) — clean
- [x] `cargo fmt` — clean
- [x] Manual TUI check against a live daemon (table columns/heights, `t` toggle, details block, footer actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)