### PR TITLE
refactor: deduplicate resource table implementations

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,7 @@ use crate::ui::container_table::{ContainerTable, ContainerTableRow};
 use crate::ui::image_table::{ImageTable, ImageTableRow};
 use crate::ui::info_block::ScrollableInfoBlock;
 use crate::ui::network_table::{NetworkTable, NetworkTableRow};
-use crate::ui::resource_table::ResourceTable;
+use crate::ui::resource_table::{ResourceRow, ResourceTable};
 use crate::ui::volume_table::{VolumeTable, VolumeTableRow};
 use color_eyre::eyre::Result;
 use ratatui::Frame;
@@ -215,14 +215,14 @@ impl App {
 
     async fn restart_container(&mut self, container_id: String) -> Result<()> {
         if let Err(e) = self.docker_client.restart_container(&container_id).await {
-            self.container_table.show_container_err(e.to_string());
+            self.container_table.show_err(e.to_string());
         }
         Ok(())
     }
 
     async fn remove_container(&mut self, container_id: String) -> Result<()> {
         if let Err(e) = self.docker_client.remove_container(&container_id).await {
-            self.container_table.show_container_err(e.to_string());
+            self.container_table.show_err(e.to_string());
         }
         Ok(())
     }
@@ -261,21 +261,21 @@ impl App {
 
     async fn remove_volume(&mut self, name: String, force: bool) -> Result<()> {
         if let Err(e) = self.docker_client.remove_volume(&name, force).await {
-            self.volume_table.show_remove_volume_err(e.to_string());
+            self.volume_table.show_err(e.to_string());
         }
         Ok(())
     }
 
     async fn remove_network(&mut self, name: String) -> Result<()> {
         if let Err(e) = self.docker_client.remove_network(&name).await {
-            self.network_table.show_remove_network_err(e.to_string());
+            self.network_table.show_err(e.to_string());
         }
         Ok(())
     }
 
     async fn remove_image(&mut self, id: String, force: bool) -> Result<()> {
         if let Err(e) = self.docker_client.remove_image(&id, force).await {
-            self.image_table.show_remove_image_err(e.to_string());
+            self.image_table.show_err(e.to_string());
         }
         Ok(())
     }

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -6,6 +6,26 @@ use ratatui::{
 };
 use std::time::{SystemTime, UNIX_EPOCH};
 
+const REFRESH_AFTER_TICK: u8 = 10;
+
+#[derive(Default, Clone)]
+pub struct RefreshTicker {
+    skipped_tick_count: u8,
+}
+
+impl RefreshTicker {
+    /// Returns true once every `REFRESH_AFTER_TICK + 2` ticks, resetting the counter.
+    pub fn should_refresh(&mut self) -> bool {
+        if self.skipped_tick_count <= REFRESH_AFTER_TICK {
+            self.skipped_tick_count += 1;
+            false
+        } else {
+            self.skipped_tick_count = 0;
+            true
+        }
+    }
+}
+
 pub struct TableStyle {
     pub header_style: Style,
     pub selected_row_style: Style,
@@ -33,11 +53,28 @@ impl Default for TableStyle {
     }
 }
 
-pub fn render_scrollbar(frame: &mut Frame, area: Rect, state: &mut ScrollbarState, is_vertical: bool) {
+pub fn render_scrollbar(
+    frame: &mut Frame,
+    area: Rect,
+    state: &mut ScrollbarState,
+    is_vertical: bool,
+) {
     let (orientation, begin_symbol, end_symbol, track_symbol, thumb_symbol) = if is_vertical {
-        (ScrollbarOrientation::VerticalRight, Some("^"), Some("v"), Some("│"), "█")
+        (
+            ScrollbarOrientation::VerticalRight,
+            Some("^"),
+            Some("v"),
+            Some("│"),
+            "█",
+        )
     } else {
-        (ScrollbarOrientation::HorizontalBottom, Some("<"), Some(">"), Some("─"), "■")
+        (
+            ScrollbarOrientation::HorizontalBottom,
+            Some("<"),
+            Some(">"),
+            Some("─"),
+            "■",
+        )
     };
 
     let scrollbar = Scrollbar::new(orientation)
@@ -94,5 +131,25 @@ pub fn time_ago_string(epoch_secs: i64) -> String {
         format!("{value} {unit}{plural} ago")
     } else {
         format!("in {value} {unit}{plural}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refresh_ticker_fires_every_twelfth_tick() {
+        let mut ticker = RefreshTicker::default();
+
+        for _ in 0..11 {
+            assert!(!ticker.should_refresh());
+        }
+        assert!(ticker.should_refresh());
+
+        for _ in 0..11 {
+            assert!(!ticker.should_refresh());
+        }
+        assert!(ticker.should_refresh());
     }
 }

--- a/src/ui/container_info_block.rs
+++ b/src/ui/container_info_block.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use crate::docker::models::{Mount, PortConfig};
 use crate::{event::AppEvent, utils::is_container_running};
 
-use super::common::{render_footer, render_scrollbar};
+use super::common::{RefreshTicker, render_footer, render_scrollbar};
 use bollard::secret::{ContainerInspectResponse, ContainerStateStatusEnum};
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
@@ -21,7 +21,7 @@ use super::info_block::{ScrollInfo, ScrollableInfoBlock};
 pub struct ContainerInfoBlock {
     data: ContainerData,
     scroll_info: ScrollInfo,
-    skipped_tick_count_for_refresh: u8,
+    ticker: RefreshTicker,
 }
 
 #[derive(Clone)]
@@ -140,11 +140,9 @@ impl ScrollableInfoBlock for ContainerInfoBlock {
     }
 
     fn tick(&mut self) -> Result<Option<AppEvent>> {
-        let event = if self.skipped_tick_count_for_refresh > 10 {
-            self.skipped_tick_count_for_refresh = 0;
+        let event = if self.ticker.should_refresh() {
             Some(AppEvent::UpdateContainerInfo(self.data.id.clone()))
         } else {
-            self.skipped_tick_count_for_refresh += 1;
             None
         };
         Ok(event)

--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -1,26 +1,19 @@
 use crate::docker::models::{PortMapping, parse_container_state, state_label};
-use crate::ui::resource_table::ResourceTableInfo;
-use crate::{event::AppEvent, ui::resource_table::ResourceTable, utils::is_container_running};
+use crate::ui::resource_table::{
+    DEFAULT_ROW_HEIGHT, KeyOutcome, ResourceRow, ResourceTable, ResourceTableInfo,
+};
+use crate::{event::AppEvent, utils::is_container_running};
 
-use super::common::{TableStyle, render_footer};
 use bollard::secret::{ContainerStateStatusEnum, ContainerSummary};
 use color_eyre::Result;
-use ratatui::style::Stylize;
 use ratatui::{
-    Frame,
     crossterm::event::{KeyCode, KeyEvent},
-    layout::{Constraint, Rect},
-    style::Style,
-    text::Text,
-    widgets::{Cell, HighlightSpacing, Row, Table},
+    layout::Constraint,
 };
 
 pub struct ContainerTable {
-    style: TableStyle,
     show_all: bool,
-    skipped_tick_count_for_update: u8,
     info: ResourceTableInfo<ContainerTableRow>,
-    err: Option<String>,
 }
 
 pub struct ContainerTableRow {
@@ -34,11 +27,8 @@ pub struct ContainerTableRow {
 impl Default for ContainerTable {
     fn default() -> Self {
         Self {
-            style: TableStyle::default(),
             show_all: true,
-            skipped_tick_count_for_update: 0,
             info: ResourceTableInfo::default(),
-            err: None,
         }
     }
 }
@@ -46,239 +36,90 @@ impl Default for ContainerTable {
 impl ResourceTable for ContainerTable {
     type RowType = ContainerTableRow;
 
-    fn get_table_info(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
+    const HEADERS: &'static [&'static str] = &["ID", "Name", "Image", "State", "Ports"];
+    const WIDTHS: &'static [Constraint] = &[
+        Constraint::Length(12),
+        Constraint::Percentage(20),
+        Constraint::Percentage(30),
+        Constraint::Percentage(10),
+        Constraint::Min(15),
+    ];
+    const DEFAULT_FOOTER: &'static str = "";
+
+    fn table_info(&self) -> &ResourceTableInfo<Self::RowType> {
+        &self.info
+    }
+
+    fn table_info_mut(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
         &mut self.info
     }
 
-    // The selection index refers to the rendered (filtered) rows, so it must be
-    // resolved and wrapped against the visible list, not `items`.
-    fn get_selected_row(&mut self) -> Option<&Self::RowType> {
-        let index = self.info.state.selected()?;
-        let item_index = *self.visible_indices().get(index)?;
-        self.info.items.get(item_index)
+    fn refresh_event(&self) -> AppEvent {
+        AppEvent::UpdateContainers
     }
 
-    fn next_row(&mut self) {
-        let Some(last_index) = self.visible_indices().len().checked_sub(1) else {
-            return;
-        };
-        let next_index = self
-            .info
-            .state
-            .selected()
-            .map_or(0, |i| if i >= last_index { 0 } else { i + 1 });
-        self.select_row(next_index);
+    fn is_row_visible(&self, row: &Self::RowType) -> bool {
+        self.show_all || is_container_running(row.state)
     }
 
-    fn previous_row(&mut self) {
-        let Some(last_index) = self.visible_indices().len().checked_sub(1) else {
-            return;
-        };
-        let previous_index = self
-            .info
-            .state
-            .selected()
-            .map_or(0, |i| if i == 0 { last_index } else { i - 1 });
-        self.select_row(previous_index);
+    fn footer_text(&self) -> String {
+        let is_selected_container_running =
+            self.selected_row().map(|c| is_container_running(c.state));
+        get_footer_text(self.show_all, is_selected_container_running)
     }
 
-    fn render_table(&mut self, frame: &mut Frame, area: Rect) {
-        let header = ["ID", "Name", "Image", "State", "Ports"]
-            .into_iter()
-            .map(Cell::from)
-            .collect::<Row>()
-            .style(self.style.header_style)
-            .height(1);
-
-        self.info.row_heights.clear();
-
-        let show_all = self.show_all;
-        let visible_items: Vec<&ContainerTableRow> = self
-            .info
-            .items
-            .iter()
-            .filter(|container| show_all || is_container_running(container.state))
-            .collect();
-        let visible_count = visible_items.len();
-
-        let rows = visible_items
-            .into_iter()
-            .enumerate()
-            .map(|(index, container)| {
-                let row_style = if index % 2 == 0 {
-                    self.style.row_style
-                } else {
-                    self.style.alt_row_style
-                };
-                let item = container.cells();
-                let port_count = container.ports.len();
-                let height = if port_count == 0 { 3 } else { port_count + 2 };
-                if index < visible_count - 1 {
-                    self.info.row_heights.push(height);
-                }
-
-                item.into_iter()
-                    .map(|content| Cell::from(Text::from(format!("\n{content}\n"))))
-                    .collect::<Row>()
-                    .style(row_style)
-                    .height(height as u16)
-            });
-
-        let widths = vec![
-            Constraint::Length(12),
-            Constraint::Percentage(20),
-            Constraint::Percentage(30),
-            Constraint::Percentage(10),
-            Constraint::Min(15),
-        ];
-
-        let table = Table::new(rows, widths)
-            .header(header)
-            .row_highlight_style(self.style.selected_row_style)
-            .highlight_symbol(Text::from(vec!["".into(), " ● ".into()]))
-            .highlight_spacing(HighlightSpacing::Always);
-
-        frame.render_stateful_widget(table, area, &mut self.info.state);
-    }
-
-    fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
-        let mut border_style = None;
-
-        let is_selected_container_running = self
-            .get_selected_row()
-            .map(|c| is_container_running(c.state));
-        let mut footer_text = get_footer_text(self.show_all, is_selected_container_running);
-
-        if let Some(err) = &self.err {
-            border_style = Some(Style::new().red());
-            footer_text = err.clone();
+    fn after_draw(&mut self) {
+        // If there is items but no row selected, select the first row.
+        // This happens when changing the `self.show_all` parameter.
+        if self.table_info().state.selected().is_none() && !self.visible_indices().is_empty() {
+            self.select_row(0);
         }
-
-        render_footer(frame, area, footer_text, border_style);
-    }
-}
-
-impl ContainerTable {
-    /// Indices into `info.items` for the rows that are currently visible.
-    /// Rendering, navigation and selection resolution all share this view.
-    fn visible_indices(&self) -> Vec<usize> {
-        self.info
-            .items
-            .iter()
-            .enumerate()
-            .filter(|(_, container)| self.show_all || is_container_running(container.state))
-            .map(|(index, _)| index)
-            .collect()
     }
 
-    pub fn handle_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
-        if self.err.is_some() {
-            self.err = None;
-            return Ok(None);
-        }
-
-        let event = match key_event.code {
+    fn handle_resource_key_event(&mut self, key_event: KeyEvent) -> Result<KeyOutcome> {
+        let outcome = match key_event.code {
             KeyCode::Char('t') => {
                 self.show_all = !self.show_all;
                 // The old selection index may point past the new visible list; clamp it.
                 if let Some(last_index) = self.visible_indices().len().checked_sub(1) {
-                    let selected = self.info.state.selected().unwrap_or(0);
+                    let selected = self.table_info().state.selected().unwrap_or(0);
                     self.select_row(selected.min(last_index));
                 }
-                None
+                KeyOutcome::Handled(None)
             }
-            KeyCode::Delete | KeyCode::Char('d') => self
-                .get_selected_row()
-                .map(|c| AppEvent::RemoveContainer(c.id.clone())),
-            KeyCode::Enter => self
-                .get_selected_row()
-                .map(|c| AppEvent::GoToContainerDetails(c.id.clone())),
-            KeyCode::Char(c) => match (c, self.get_selected_row().map(|c| c.id.clone())) {
-                ('r', Some(id)) => Some(AppEvent::RestartContainer(id)),
-                ('s', Some(id)) => Some(AppEvent::StopContainer(id)),
-                ('x', Some(id)) => Some(AppEvent::KillContainer(id)),
-                _ => self.handle_nav_key_event(key_event)?,
+            KeyCode::Delete | KeyCode::Char('d') => KeyOutcome::Handled(
+                self.selected_row()
+                    .map(|c| AppEvent::RemoveContainer(c.id.clone())),
+            ),
+            KeyCode::Enter => KeyOutcome::Handled(
+                self.selected_row()
+                    .map(|c| AppEvent::GoToContainerDetails(c.id.clone())),
+            ),
+            KeyCode::Char(c) => match (c, self.selected_row().map(|c| c.id.clone())) {
+                ('r', Some(id)) => KeyOutcome::Handled(Some(AppEvent::RestartContainer(id))),
+                ('s', Some(id)) => KeyOutcome::Handled(Some(AppEvent::StopContainer(id))),
+                ('x', Some(id)) => KeyOutcome::Handled(Some(AppEvent::KillContainer(id))),
+                _ => KeyOutcome::Fallthrough,
             },
-            _ => None,
+            _ => KeyOutcome::Handled(None),
         };
 
-        Ok(event)
+        Ok(outcome)
     }
 
-    pub fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        let result = self.draw_default(frame, area);
-
-        // If there is items but no row selected, select the first row.
-        // This happens when changing the `self.show_all` parameter.
-        if self.info.state.selected().is_none() && !self.visible_indices().is_empty() {
-            self.select_row(0);
-        }
-
-        result
-    }
-
-    pub fn tick(&mut self) -> Result<Option<AppEvent>> {
-        if self.skipped_tick_count_for_update <= 10 {
-            self.skipped_tick_count_for_update += 1;
-            return Ok(None);
-        }
-
-        self.skipped_tick_count_for_update = 0;
-        Ok(Some(AppEvent::UpdateContainers))
-    }
-
-    pub fn show_container_err(&mut self, err: String) {
-        let err_msg = err
-            .split(":")
+    fn error_message(&self, raw: &str) -> String {
+        raw.split(":")
             .collect::<Vec<&str>>()
             .get(2)
-            .map_or("Something went wrong...", |v| v);
-        self.err = Some(format!("[ERR] {}", err_msg.trim()))
+            .map_or("Something went wrong...", |v| v)
+            .to_string()
     }
 }
 
-impl ContainerTableRow {
-    fn cells(&self) -> [String; 5] {
-        let ports_text = if self.ports.is_empty() {
-            "-".to_string()
-        } else {
-            self.ports
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<String>>()
-                .join("\n")
-        };
+impl ResourceRow for ContainerTableRow {
+    type Source = ContainerSummary;
 
-        [
-            self.id.clone(),
-            self.name.clone(),
-            self.image.clone(),
-            state_label(self.state),
-            ports_text,
-        ]
-    }
-
-    pub fn from_list(containers: Vec<ContainerSummary>) -> Vec<Self> {
-        let mut result_list = containers
-            .iter()
-            .map(ContainerTableRow::from)
-            .collect::<Vec<ContainerTableRow>>();
-
-        result_list.sort_by(|p, n| {
-            let p_is_running = p.state == ContainerStateStatusEnum::RUNNING;
-            let n_is_running = n.state == ContainerStateStatusEnum::RUNNING;
-
-            match (p_is_running, n_is_running) {
-                (true, false) => std::cmp::Ordering::Less,
-                (false, true) => std::cmp::Ordering::Greater,
-                _ => p.state.as_ref().cmp(n.state.as_ref()),
-            }
-        });
-
-        result_list
-    }
-
-    fn from(container: &ContainerSummary) -> Self {
+    fn from_source(container: &Self::Source) -> Self {
         let name: String = container
             .names
             .as_deref()
@@ -297,6 +138,47 @@ impl ContainerTableRow {
                 .map(PortMapping::from_summary_ports)
                 .unwrap_or_default(),
         }
+    }
+
+    fn cells(&self) -> Vec<String> {
+        let ports_text = if self.ports.is_empty() {
+            "-".to_string()
+        } else {
+            self.ports
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<String>>()
+                .join("\n")
+        };
+
+        vec![
+            self.id.clone(),
+            self.name.clone(),
+            self.image.clone(),
+            state_label(self.state),
+            ports_text,
+        ]
+    }
+
+    fn height(&self) -> usize {
+        if self.ports.is_empty() {
+            DEFAULT_ROW_HEIGHT
+        } else {
+            self.ports.len() + 2
+        }
+    }
+
+    fn sort_rows(rows: &mut Vec<Self>) {
+        rows.sort_by(|p, n| {
+            let p_is_running = p.state == ContainerStateStatusEnum::RUNNING;
+            let n_is_running = n.state == ContainerStateStatusEnum::RUNNING;
+
+            match (p_is_running, n_is_running) {
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                _ => p.state.as_ref().cmp(n.state.as_ref()),
+            }
+        });
     }
 }
 
@@ -365,14 +247,14 @@ mod tests {
     #[test]
     fn from_strips_leading_slash_from_name() {
         let container = summary_with_state("running");
-        let row = ContainerTableRow::from(&container);
+        let row = ContainerTableRow::from_source(&container);
         assert_eq!(row.name, "running");
     }
 
     #[test]
     fn cells_fall_back_to_dash_for_missing_fields() {
         let container = ContainerSummary::default();
-        let row = ContainerTableRow::from(&container);
+        let row = ContainerTableRow::from_source(&container);
         let cells = row.cells();
 
         assert_eq!(cells[0], "-"); // id

--- a/src/ui/image_table.rs
+++ b/src/ui/image_table.rs
@@ -1,34 +1,25 @@
 use bollard::secret::ImageSummary;
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
-use ratatui::{
-    Frame,
-    layout::{Constraint, Rect},
-    style::{Style, Stylize},
-    text::Text,
-    widgets::{Cell, HighlightSpacing, Row, Table},
-};
+use ratatui::layout::Constraint;
+use regex::Regex;
 
 use crate::{
     event::AppEvent,
     ui::{
-        common::{TableStyle, render_footer, time_ago_string},
-        resource_table::{ResourceTable, ResourceTableInfo},
+        common::time_ago_string,
+        resource_table::{
+            DEFAULT_ROW_HEIGHT, KeyOutcome, ResourceRow, ResourceTable, ResourceTableInfo,
+        },
     },
 };
 
-use regex::Regex;
-
-const REFRESH_AFTER_TICK: u8 = 10;
-const REGEX_DELETE_IMG_ERR: &str = r"\((?:cannot|must) be forced\) - image is being used by (?:running|stopped) container \w+";
-const DEFAULT_FOOTER: &str = " <Del/D> remove | <F> force remove";
+const REGEX_DELETE_IMG_ERR: &str =
+    r"\((?:cannot|must) be forced\) - image is being used by (?:running|stopped) container \w+";
 
 #[derive(Default)]
 pub struct ImageTable {
-    style: TableStyle,
-    skipped_tick_count_for_refresh: u8,
     info: ResourceTableInfo<ImageTableRow>,
-    err: Option<String>,
 }
 
 #[derive(Default)]
@@ -37,126 +28,63 @@ pub struct ImageTableRow {
     tags: String,
     size: String,
     created: String,
+    created_epoch: i64,
 }
 
 impl ResourceTable for ImageTable {
     type RowType = ImageTableRow;
 
-    fn get_table_info(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
+    const HEADERS: &'static [&'static str] = &["ID", "Tags", "Size", "Created"];
+    const WIDTHS: &'static [Constraint] = &[
+        Constraint::Length(15),
+        Constraint::Min(15),
+        Constraint::Min(0),
+        Constraint::Length(27),
+    ];
+    const DEFAULT_FOOTER: &'static str = " <Del/D> remove | <F> force remove";
+
+    fn table_info(&self) -> &ResourceTableInfo<Self::RowType> {
+        &self.info
+    }
+
+    fn table_info_mut(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
         &mut self.info
     }
 
-    fn render_table(&mut self, frame: &mut Frame, area: Rect) {
-        let header = ["ID", "Tags", "Size", "Created"].into_iter()
-            .map(Cell::from)
-            .collect::<Row>()
-            .style(self.style.header_style)
-            .height(1);
-
-        self.info.row_heights.clear();
-
-        let rows = self.info.items.iter().enumerate().map(|(index, image)| {
-            let row_style = if index % 2 == 0 { self.style.row_style } else { self.style.alt_row_style };
-            let item = image.ref_array();
-            let tags: Vec<&str> = image.tags.split("\n").filter(|s| !s.is_empty()).collect();
-
-            let height = if tags.is_empty() { 3 } else { tags.len() + 2 };
-            if index < self.info.items.len() - 1 {
-                self.info.row_heights.push(height);
-            }
-
-            item.into_iter()
-                .map(|content| Cell::from(Text::from(format!("\n{content}\n"))))
-                .collect::<Row>()
-                .style(row_style)
-                .height(height as u16)
-        });
-
-        let widths = vec![
-            Constraint::Length(15),
-            Constraint::Min(15),
-            Constraint::Min(0),
-            Constraint::Length(27),
-        ];
-
-        let table = Table::new(rows, widths)
-            .header(header)
-            .row_highlight_style(self.style.selected_row_style)
-            .highlight_symbol(Text::from(vec!["".into(), " ● ".into()]))
-            .highlight_spacing(HighlightSpacing::Always);
-
-        frame.render_stateful_widget(table, area, &mut self.info.state);
+    fn refresh_event(&self) -> AppEvent {
+        AppEvent::UpdateImages
     }
 
-    fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
-        let mut border_style = None;
-        let mut footer_text = DEFAULT_FOOTER.to_string();
-
-        if let Some(err) = &self.err {
-            border_style = Some(Style::new().red());
-            footer_text = err.clone();
-        }
-
-        render_footer(frame, area, footer_text, border_style);
-    }
-}
-
-impl ImageTable {
-    pub fn handle_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
-        if self.err.is_some() {
-            self.err = None;
-            return Ok(None);
-        }
-
-        let event = match key_event.code {
-            KeyCode::Delete | KeyCode::Char('d') => self.get_selected_row()
-                .map(|i| AppEvent::RemoveImage(i.id.clone(), false)),
-            KeyCode::Char('f') => self.get_selected_row()
-                .map(|i| AppEvent::RemoveImage(i.id.clone(), true)),
-            _ => self.handle_nav_key_event(key_event)?,
+    fn handle_resource_key_event(&mut self, key_event: KeyEvent) -> Result<KeyOutcome> {
+        let outcome = match key_event.code {
+            KeyCode::Delete | KeyCode::Char('d') => KeyOutcome::Handled(
+                self.selected_row()
+                    .map(|i| AppEvent::RemoveImage(i.id.clone(), false)),
+            ),
+            KeyCode::Char('f') => KeyOutcome::Handled(
+                self.selected_row()
+                    .map(|i| AppEvent::RemoveImage(i.id.clone(), true)),
+            ),
+            _ => KeyOutcome::Fallthrough,
         };
 
-        Ok(event)
+        Ok(outcome)
     }
 
-    pub fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        self.draw_default(frame, area)
-    }
-
-    pub fn tick(&mut self) -> Result<Option<AppEvent>> {
-        if self.skipped_tick_count_for_refresh <= REFRESH_AFTER_TICK {
-            self.skipped_tick_count_for_refresh += 1;
-            return Ok(None);
-        }
-
-        self.skipped_tick_count_for_refresh = 0;
-        Ok(Some(AppEvent::UpdateImages))
-    }
-
-    pub fn show_remove_image_err(&mut self, err: String) {
-        let err_msg = Regex::new(REGEX_DELETE_IMG_ERR).ok()
-            .and_then(|re| re.find(&err))
+    fn error_message(&self, raw: &str) -> String {
+        Regex::new(REGEX_DELETE_IMG_ERR)
+            .ok()
+            .and_then(|re| re.find(raw))
             .map(|m| m.as_str())
-            .unwrap_or_else(|| "Something went wrong...")
-            .to_string();
-
-        self.err = Some(format!("[ERR] {}", err_msg.trim()))
+            .unwrap_or("Something went wrong...")
+            .to_string()
     }
 }
 
-impl ImageTableRow {
-    const fn ref_array(&self) -> [&String; 4] {
-        [&self.id, &self.tags, &self.size, &self.created]
-    }
+impl ResourceRow for ImageTableRow {
+    type Source = ImageSummary;
 
-    pub fn from_list(images: Vec<ImageSummary>) -> Vec<Self> {
-        let mut result = images.clone();
-        result.sort_by_key(|i| i.created);
-        result.reverse();
-        result.iter().map(Self::from).collect::<Vec<Self>>()
-    }
-
-    fn from(image: &ImageSummary) -> Self {
+    fn from_source(image: &Self::Source) -> Self {
         let id = image.id.split(":").collect::<Vec<&str>>()[1].to_string();
 
         Self {
@@ -164,6 +92,52 @@ impl ImageTableRow {
             tags: image.repo_tags.join("\n"),
             size: image.size.to_string(),
             created: time_ago_string(image.created),
+            created_epoch: image.created,
         }
+    }
+
+    fn cells(&self) -> Vec<String> {
+        vec![
+            self.id.clone(),
+            self.tags.clone(),
+            self.size.clone(),
+            self.created.clone(),
+        ]
+    }
+
+    fn height(&self) -> usize {
+        let tags = self.tags.split('\n').filter(|s| !s.is_empty()).count();
+        if tags == 0 {
+            DEFAULT_ROW_HEIGHT
+        } else {
+            tags + 2
+        }
+    }
+
+    fn sort_rows(rows: &mut Vec<Self>) {
+        rows.sort_by_key(|r| r.created_epoch);
+        rows.reverse();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn image(id: &str, created: i64) -> ImageSummary {
+        ImageSummary {
+            id: format!("sha256:{id}"),
+            created,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn from_list_sorts_newest_first() {
+        let images = vec![image("a", 100), image("b", 300), image("c", 200)];
+        let rows = ImageTableRow::from_list(images);
+        let ids: Vec<String> = rows.iter().map(|r| r.id.clone()).collect();
+
+        assert_eq!(ids, vec!["b", "c", "a"]);
     }
 }

--- a/src/ui/network_table.rs
+++ b/src/ui/network_table.rs
@@ -1,33 +1,20 @@
-use super::common::TableStyle;
-use super::common::render_footer;
-use crate::event::AppEvent;
-use crate::ui::resource_table::ResourceTable;
-use crate::ui::resource_table::ResourceTableInfo;
 use bollard::secret::Network;
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
-use ratatui::style::Stylize;
-use ratatui::{
-    Frame,
-    layout::{Constraint, Rect},
-    style::Style,
-    text::Text,
-    widgets::{Cell, HighlightSpacing, Row, Table},
-};
+use ratatui::layout::Constraint;
 use regex::Regex;
 
-const ROW_HEIGHT: usize = 3;
-const REFRESH_AFTER_TICK: u8 = 10;
+use crate::{
+    event::AppEvent,
+    ui::resource_table::{KeyOutcome, ResourceRow, ResourceTable, ResourceTableInfo},
+};
+
 const REGEX_NETWORK_IN_USE: &str = r":(?:[^:]+:)?\s*([^\(]+)";
 const REGEX_NETWORK_CREATED_AT: &str = r"\.\d+";
-const DEFAULT_FOOTER: &str = " <Del/D> remove";
 
 #[derive(Default)]
 pub struct NetworkTable {
-    style: TableStyle,
-    skipped_tick_count_for_refresh: u8,
     info: ResourceTableInfo<NetworkTableRow>,
-    err: Option<String>,
 }
 
 #[derive(Default)]
@@ -41,116 +28,53 @@ pub struct NetworkTableRow {
 impl ResourceTable for NetworkTable {
     type RowType = NetworkTableRow;
 
-    fn get_table_info(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
+    const HEADERS: &'static [&'static str] = &["ID", "Name", "Driver", "Created At"];
+    const WIDTHS: &'static [Constraint] = &[
+        Constraint::Length(15),
+        Constraint::Min(15),
+        Constraint::Min(0),
+        Constraint::Length(27),
+    ];
+    const DEFAULT_FOOTER: &'static str = " <Del/D> remove";
+
+    fn table_info(&self) -> &ResourceTableInfo<Self::RowType> {
+        &self.info
+    }
+
+    fn table_info_mut(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
         &mut self.info
     }
 
-    fn render_table(&mut self, frame: &mut Frame, area: Rect) {
-        let header = ["ID", "Name", "Driver", "Created At"].into_iter()
-            .map(Cell::from)
-            .collect::<Row>()
-            .style(self.style.header_style)
-            .height(1);
-
-        self.info.row_heights.clear();
-
-        let rows = self.info.items.iter().enumerate().map(|(index, network)| {
-            let row_style = if index % 2 == 0 { self.style.row_style} else { self.style.alt_row_style };
-            let item = network.ref_array();
-
-            if index < self.info.items.len() - 1 {
-                self.info.row_heights.push(ROW_HEIGHT);
-            }
-
-            item.into_iter()
-                .map(|content| Cell::from(Text::from(format!("\n{content}\n"))))
-                .collect::<Row>()
-                .style(row_style)
-                .height(ROW_HEIGHT as u16)
-        });
-
-        let widths = vec![
-            Constraint::Length(15),
-            Constraint::Min(15),
-            Constraint::Min(0),
-            Constraint::Length(27),
-        ];
-
-        let table = Table::new(rows, widths)
-            .header(header)
-            .row_highlight_style(self.style.selected_row_style)
-            .highlight_symbol(Text::from(vec!["".into(), " ● ".into()]))
-            .highlight_spacing(HighlightSpacing::Always);
-
-        frame.render_stateful_widget(table, area, &mut self.info.state);
+    fn refresh_event(&self) -> AppEvent {
+        AppEvent::UpdateNetworks
     }
 
-    fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
-        let mut border_style = None;
-        let mut footer_text = DEFAULT_FOOTER.to_string();
-
-        if let Some(err) = &self.err {
-            border_style = Some(Style::new().red());
-            footer_text = err.clone();
-        }
-
-        render_footer(frame, area, footer_text, border_style);
-    }
-}
-
-impl NetworkTable {
-    pub fn handle_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
-        if self.err.is_some() {
-            self.err = None;
-            return Ok(None);
-        }
-
-        let event = match key_event.code {
-            KeyCode::Delete | KeyCode::Char('d') => self.get_selected_row()
-                .map(|n| AppEvent::RemoveNetwork(n.name.clone())),
-            _ => self.handle_nav_key_event(key_event)?,
+    fn handle_resource_key_event(&mut self, key_event: KeyEvent) -> Result<KeyOutcome> {
+        let outcome = match key_event.code {
+            KeyCode::Delete | KeyCode::Char('d') => KeyOutcome::Handled(
+                self.selected_row()
+                    .map(|n| AppEvent::RemoveNetwork(n.name.clone())),
+            ),
+            _ => KeyOutcome::Fallthrough,
         };
 
-        Ok(event)
+        Ok(outcome)
     }
 
-    pub fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        self.draw_default(frame, area)
-    }
-
-    pub fn tick(&mut self) -> Result<Option<AppEvent>> {
-        if self.skipped_tick_count_for_refresh <= REFRESH_AFTER_TICK {
-            self.skipped_tick_count_for_refresh += 1;
-            return Ok(None);
-        }
-
-        self.skipped_tick_count_for_refresh = 0;
-        Ok(Some(AppEvent::UpdateNetworks))
-    }
-
-    pub fn show_remove_network_err(&mut self, err: String) {
-        let err_msg = Regex::new(REGEX_NETWORK_IN_USE).ok()
-            .and_then(|re| re.captures(&err))
+    fn error_message(&self, raw: &str) -> String {
+        Regex::new(REGEX_NETWORK_IN_USE)
+            .ok()
+            .and_then(|re| re.captures(raw))
             .and_then(|caps| caps.get(1))
             .map(|m| m.as_str().to_string())
-            .unwrap_or_else(|| "Something went wrong...".to_string());
-
-        self.err = Some(format!("[ERR] {}", err_msg.trim()))
+            .unwrap_or_else(|| "Something went wrong...".to_string())
     }
 }
 
-impl NetworkTableRow {
-    const fn ref_array(&self) -> [&String; 4] {
-        [&self.id, &self.name, &self.driver, &self.created_at]
-    }
+impl ResourceRow for NetworkTableRow {
+    type Source = Network;
 
-    pub fn from_list(networks: Vec<Network>) -> Vec<Self> {
-        let mut result = networks.iter().map(Self::from).collect::<Vec<Self>>();
-        result.sort_by_key(|n| n.name.clone());
-        result
-    }
-
-    fn from(network: &Network) -> Self {
+    fn from_source(network: &Self::Source) -> Self {
         let id = format!("{}...", &network.id.as_deref().unwrap_or("-")[..12]);
 
         let raw_created = network.created.as_deref().unwrap_or_default();
@@ -163,5 +87,45 @@ impl NetworkTableRow {
             driver: network.driver.as_deref().unwrap_or("-").to_string(),
             created_at,
         }
+    }
+
+    fn cells(&self) -> Vec<String> {
+        vec![
+            self.id.clone(),
+            self.name.clone(),
+            self.driver.clone(),
+            self.created_at.clone(),
+        ]
+    }
+
+    fn sort_rows(rows: &mut Vec<Self>) {
+        rows.sort_by_key(|n| n.name.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn network(id: &str, name: &str) -> Network {
+        Network {
+            id: Some(id.to_string()),
+            name: Some(name.to_string()),
+            driver: Some("bridge".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn from_list_sorts_by_name() {
+        let networks = vec![
+            network("111111111111", "charlie"),
+            network("222222222222", "alpha"),
+            network("333333333333", "bravo"),
+        ];
+        let rows = NetworkTableRow::from_list(networks);
+        let names: Vec<String> = rows.iter().map(|r| r.name.clone()).collect();
+
+        assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
     }
 }

--- a/src/ui/resource_table.rs
+++ b/src/ui/resource_table.rs
@@ -3,17 +3,27 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
-    widgets::{ScrollbarState, TableState},
+    style::{Style, Stylize},
+    text::Text,
+    widgets::{Cell, HighlightSpacing, Row, ScrollbarState, Table, TableState},
 };
 
-use crate::{event::AppEvent, ui::common::render_scrollbar};
+use crate::{
+    event::AppEvent,
+    ui::common::{RefreshTicker, TableStyle, render_scrollbar},
+};
+
+pub const DEFAULT_ROW_HEIGHT: usize = 3;
 
 pub struct ResourceTableInfo<RowType> {
     pub items: Vec<RowType>,
     pub state: TableState,
+    pub row_heights: Vec<usize>,
+    pub style: TableStyle,
+    pub err: Option<String>,
+    pub ticker: RefreshTicker,
     scrollbar_state: ScrollbarState,
     scroll: usize,
-    pub row_heights: Vec<usize>,
 }
 
 impl<RowType> Default for ResourceTableInfo<RowType> {
@@ -21,17 +31,121 @@ impl<RowType> Default for ResourceTableInfo<RowType> {
         Self {
             items: vec![],
             state: TableState::default().with_selected(0),
+            row_heights: vec![],
+            style: TableStyle::default(),
+            err: None,
+            ticker: RefreshTicker::default(),
             scrollbar_state: ScrollbarState::default(),
             scroll: 0,
-            row_heights: vec![],
         }
     }
 }
 
-pub trait ResourceTable {
-    type RowType;
+/// A single row of a `ResourceTable`, projected from a source Docker API type.
+pub trait ResourceRow: Sized {
+    type Source;
 
-    fn get_table_info(&mut self) -> &mut ResourceTableInfo<Self::RowType>;
+    fn from_source(source: &Self::Source) -> Self;
+
+    fn cells(&self) -> Vec<String>;
+
+    fn height(&self) -> usize {
+        DEFAULT_ROW_HEIGHT
+    }
+
+    /// Sorts the rows in place. Default preserves the API's original order.
+    fn sort_rows(_rows: &mut Vec<Self>) {}
+
+    fn from_list(sources: Vec<Self::Source>) -> Vec<Self> {
+        let mut rows = sources.iter().map(Self::from_source).collect::<Vec<Self>>();
+        Self::sort_rows(&mut rows);
+        rows
+    }
+}
+
+/// Outcome of a resource-specific key handler.
+pub enum KeyOutcome {
+    /// The key was consumed; optionally emit an `AppEvent`.
+    Handled(Option<AppEvent>),
+    /// The key was not handled by the resource; fall through to shared navigation handling.
+    Fallthrough,
+}
+
+pub trait ResourceTable {
+    type RowType: ResourceRow;
+
+    const HEADERS: &'static [&'static str];
+    const WIDTHS: &'static [Constraint];
+    const DEFAULT_FOOTER: &'static str;
+
+    fn table_info(&self) -> &ResourceTableInfo<Self::RowType>;
+    fn table_info_mut(&mut self) -> &mut ResourceTableInfo<Self::RowType>;
+
+    fn refresh_event(&self) -> AppEvent;
+    fn handle_resource_key_event(&mut self, key_event: KeyEvent) -> Result<KeyOutcome>;
+    fn error_message(&self, raw: &str) -> String;
+
+    /// Whether the row is currently visible (rendered/navigable). Default: all rows visible.
+    #[allow(unused_variables)]
+    fn is_row_visible(&self, row: &Self::RowType) -> bool {
+        true
+    }
+
+    fn footer_text(&self) -> String {
+        Self::DEFAULT_FOOTER.to_string()
+    }
+
+    fn after_draw(&mut self) {}
+
+    /// Indices into `table_info().items` for the rows that are currently visible.
+    /// Rendering, navigation and selection resolution all share this view.
+    fn visible_indices(&self) -> Vec<usize> {
+        self.table_info()
+            .items
+            .iter()
+            .enumerate()
+            .filter(|(_, row)| self.is_row_visible(row))
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    // The selection index refers to the rendered (filtered) rows, so it must be
+    // resolved and wrapped against the visible list, not `items`.
+    fn selected_row(&self) -> Option<&Self::RowType> {
+        let index = self.table_info().state.selected()?;
+        let item_index = *self.visible_indices().get(index)?;
+        self.table_info().items.get(item_index)
+    }
+
+    fn next_row(&mut self) {
+        let Some(last_index) = self.visible_indices().len().checked_sub(1) else {
+            return;
+        };
+        let next_index = self
+            .table_info()
+            .state
+            .selected()
+            .map_or(0, |i| if i >= last_index { 0 } else { i + 1 });
+        self.select_row(next_index);
+    }
+
+    fn previous_row(&mut self) {
+        let Some(last_index) = self.visible_indices().len().checked_sub(1) else {
+            return;
+        };
+        let previous_index = self
+            .table_info()
+            .state
+            .selected()
+            .map_or(0, |i| if i == 0 { last_index } else { i - 1 });
+        self.select_row(previous_index);
+    }
+
+    fn select_row(&mut self, index: usize) {
+        let table_info = self.table_info_mut();
+        table_info.state.select(Some(index));
+        table_info.scroll = table_info.row_heights.iter().take(index).sum();
+    }
 
     fn handle_nav_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
         let mut event = None;
@@ -46,32 +160,91 @@ pub trait ResourceTable {
         Ok(event)
     }
 
-    fn next_row(&mut self) {
-        let table_info = self.get_table_info();
-        let Some(last_index) = table_info.items.len().checked_sub(1) else { return };
-        let next_index = table_info.state.selected().map_or(0, |i| if i >= last_index { 0 } else { i + 1 });
-        self.select_row(next_index);
+    fn update_scroll_state(&mut self) {
+        let table_info = self.table_info_mut();
+        let content_height: usize = table_info.row_heights.iter().sum();
+        table_info.scrollbar_state = table_info
+            .scrollbar_state
+            .content_length(content_height)
+            .position(table_info.scroll);
     }
 
-    fn previous_row(&mut self) {
-        let table_info = self.get_table_info();
-        let Some(last_index) = table_info.items.len().checked_sub(1) else { return };
-        let previous_index = table_info.state.selected().map_or(0, |i| if i == 0 { last_index } else { i - 1 });
-        self.select_row(previous_index);
+    fn update_with_items(&mut self, items: Vec<Self::RowType>) {
+        let table_info = self.table_info_mut();
+        let is_empty_before_update = table_info.items.is_empty();
+        table_info.items = items;
+
+        if is_empty_before_update && !table_info.items.is_empty() {
+            self.select_row(0);
+        }
     }
 
-    fn get_selected_row(&mut self) -> Option<&Self::RowType> {
-        let table_info = self.get_table_info();
-        table_info.state.selected().and_then(|index| table_info.items.get(index))
+    fn render_table(&mut self, frame: &mut Frame, area: Rect) {
+        let rows: Vec<(usize, Vec<String>)> = self
+            .visible_indices()
+            .iter()
+            .map(|&i| {
+                let row = &self.table_info().items[i];
+                (row.height(), row.cells())
+            })
+            .collect();
+
+        let heights: Vec<usize> = rows
+            .iter()
+            .map(|(h, _)| *h)
+            .take(rows.len().saturating_sub(1))
+            .collect();
+
+        let info = self.table_info_mut();
+        info.row_heights = heights;
+
+        let header = Self::HEADERS
+            .iter()
+            .map(|h| Cell::from(*h))
+            .collect::<Row>()
+            .style(info.style.header_style)
+            .height(1);
+
+        let table_rows = rows
+            .into_iter()
+            .enumerate()
+            .map(|(index, (height, cells))| {
+                let row_style = if index % 2 == 0 {
+                    info.style.row_style
+                } else {
+                    info.style.alt_row_style
+                };
+
+                cells
+                    .into_iter()
+                    .map(|content| Cell::from(Text::from(format!("\n{content}\n"))))
+                    .collect::<Row>()
+                    .style(row_style)
+                    .height(height as u16)
+            });
+
+        let table = Table::new(table_rows, Self::WIDTHS.to_vec())
+            .header(header)
+            .row_highlight_style(info.style.selected_row_style)
+            .highlight_symbol(Text::from(vec!["".into(), " ● ".into()]))
+            .highlight_spacing(HighlightSpacing::Always);
+
+        frame.render_stateful_widget(table, area, &mut info.state);
     }
 
-    fn select_row(&mut self, index: usize) {
-        let table_info = self.get_table_info();
-        table_info.state.select(Some(index));
-        table_info.scroll = table_info.row_heights.iter().take(index).sum();
+    fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
+        let mut text = self.footer_text();
+        let mut border = None;
+
+        if let Some(err) = &self.table_info().err {
+            border = Some(Style::new().red());
+            text = err.clone();
+        }
+
+        crate::ui::common::render_footer(frame, area, text, border);
     }
 
-    fn draw_default(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
         use Constraint::{Length, Min};
 
         let vertical_layout = Layout::vertical([Min(0), Length(3)]);
@@ -84,34 +257,241 @@ pub trait ResourceTable {
 
         self.update_scroll_state();
 
-        let table_info = self.get_table_info();
+        let table_info = self.table_info_mut();
         render_scrollbar(frame, scrollbar_area, &mut table_info.scrollbar_state, true);
 
         self.render_footer(frame, footer_area);
 
+        self.after_draw();
+
         Ok(())
     }
 
-    fn update_scroll_state(&mut self) {
-        let table_info = self.get_table_info();
-        let content_height: usize = table_info.row_heights.iter().sum();
-        table_info.scrollbar_state = table_info.scrollbar_state
-            .content_length(content_height)
-            .position(table_info.scroll);
+    fn tick(&mut self) -> Result<Option<AppEvent>> {
+        if self.table_info_mut().ticker.should_refresh() {
+            Ok(Some(self.refresh_event()))
+        } else {
+            Ok(None)
+        }
     }
 
-    fn render_table(&mut self, frame: &mut Frame, area: Rect);
-
-    #[allow(unused_variables)]
-    fn render_footer(&mut self, frame: &mut Frame, area: Rect) {}
-
-    fn update_with_items(&mut self, items: Vec<Self::RowType>) {
-        let table_info = self.get_table_info();
-        let is_empty_before_update = table_info.items.is_empty();
-        table_info.items = items;
-
-        if is_empty_before_update && !table_info.items.is_empty() {
-            self.select_row(0);
+    fn handle_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
+        if self.table_info().err.is_some() {
+            self.table_info_mut().err = None;
+            return Ok(None);
         }
+
+        match self.handle_resource_key_event(key_event)? {
+            KeyOutcome::Handled(event) => Ok(event),
+            KeyOutcome::Fallthrough => self.handle_nav_key_event(key_event),
+        }
+    }
+
+    fn show_err(&mut self, raw: String) {
+        let msg = self.error_message(&raw);
+        self.table_info_mut().err = Some(format!("[ERR] {}", msg.trim()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
+
+    #[derive(Default, Clone)]
+    struct TestRow {
+        label: String,
+        visible: bool,
+    }
+
+    impl ResourceRow for TestRow {
+        type Source = (String, bool);
+
+        fn from_source(source: &Self::Source) -> Self {
+            Self {
+                label: source.0.clone(),
+                visible: source.1,
+            }
+        }
+
+        fn cells(&self) -> Vec<String> {
+            vec![self.label.clone()]
+        }
+    }
+
+    #[derive(Default)]
+    struct TestTable {
+        info: ResourceTableInfo<TestRow>,
+        filter: bool,
+    }
+
+    impl ResourceTable for TestTable {
+        type RowType = TestRow;
+
+        const HEADERS: &'static [&'static str] = &["Label"];
+        const WIDTHS: &'static [Constraint] = &[Constraint::Min(10)];
+        const DEFAULT_FOOTER: &'static str = " footer";
+
+        fn table_info(&self) -> &ResourceTableInfo<Self::RowType> {
+            &self.info
+        }
+
+        fn table_info_mut(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
+            &mut self.info
+        }
+
+        fn refresh_event(&self) -> AppEvent {
+            AppEvent::UpdateContainers
+        }
+
+        fn handle_resource_key_event(&mut self, key_event: KeyEvent) -> Result<KeyOutcome> {
+            match key_event.code {
+                KeyCode::Char('h') => Ok(KeyOutcome::Handled(None)),
+                _ => Ok(KeyOutcome::Fallthrough),
+            }
+        }
+
+        fn error_message(&self, raw: &str) -> String {
+            raw.to_string()
+        }
+
+        fn is_row_visible(&self, row: &Self::RowType) -> bool {
+            !self.filter || row.visible
+        }
+    }
+
+    fn rows(labels: &[(&str, bool)]) -> Vec<TestRow> {
+        labels
+            .iter()
+            .map(|(l, v)| TestRow {
+                label: (*l).to_string(),
+                visible: *v,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn next_and_previous_row_wrap_around_visible_rows_only() {
+        let mut table = TestTable {
+            filter: true,
+            ..Default::default()
+        };
+        table.update_with_items(rows(&[("a", true), ("b", false), ("c", true)]));
+        // row heights are populated by render normally; set manually for this test.
+        table.info.row_heights = vec![DEFAULT_ROW_HEIGHT, DEFAULT_ROW_HEIGHT];
+
+        table.select_row(0);
+        assert_eq!(
+            table.selected_row().map(|r| r.label.clone()),
+            Some("a".to_string())
+        );
+
+        table.next_row();
+        // Only "a" and "c" are visible, so index 1 resolves to "c".
+        assert_eq!(
+            table.selected_row().map(|r| r.label.clone()),
+            Some("c".to_string())
+        );
+
+        table.next_row();
+        assert_eq!(
+            table.selected_row().map(|r| r.label.clone()),
+            Some("a".to_string())
+        );
+
+        table.previous_row();
+        assert_eq!(
+            table.selected_row().map(|r| r.label.clone()),
+            Some("c".to_string())
+        );
+    }
+
+    #[test]
+    fn select_row_updates_scroll_from_row_heights() {
+        let mut table = TestTable::default();
+        table.update_with_items(rows(&[("a", true), ("b", true), ("c", true)]));
+        table.info.row_heights = vec![3, 5, 7];
+
+        table.select_row(2);
+        assert_eq!(table.info.scroll, 8);
+    }
+
+    #[test]
+    fn handle_key_event_clears_error_without_dispatch() {
+        let mut table = TestTable::default();
+        table.info.err = Some("boom".to_string());
+
+        let result = table
+            .handle_key_event(KeyEvent::from(KeyCode::Char('h')))
+            .unwrap();
+        assert!(result.is_none());
+        assert!(table.info.err.is_none());
+    }
+
+    #[test]
+    fn handled_outcome_does_not_reach_nav_handling() {
+        let mut table = TestTable::default();
+        table.update_with_items(rows(&[("a", true), ("b", true)]));
+        table.info.row_heights = vec![DEFAULT_ROW_HEIGHT];
+        table.select_row(0);
+
+        table
+            .handle_key_event(KeyEvent::from(KeyCode::Char('h')))
+            .unwrap();
+        // 'h' is Handled(None) for TestTable, so selection must not move.
+        assert_eq!(table.info.state.selected(), Some(0));
+    }
+
+    #[test]
+    fn fallthrough_outcome_reaches_nav_handling() {
+        let mut table = TestTable::default();
+        table.update_with_items(rows(&[("a", true), ("b", true)]));
+        table.info.row_heights = vec![DEFAULT_ROW_HEIGHT];
+        table.select_row(0);
+
+        let event = table
+            .handle_key_event(KeyEvent::from(KeyCode::Char('j')))
+            .unwrap();
+        assert!(event.is_none());
+        assert_eq!(table.info.state.selected(), Some(1));
+
+        let event = table
+            .handle_key_event(KeyEvent::from(KeyCode::Char('q')))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::Quit)));
+    }
+
+    #[test]
+    fn update_with_items_selects_first_row_only_on_empty_to_nonempty_transition() {
+        let mut table = TestTable::default();
+        table.info.state.select(None);
+
+        table.update_with_items(rows(&[("a", true)]));
+        assert_eq!(table.info.state.selected(), Some(0));
+
+        table.select_row(0);
+        table.info.state.select(None);
+        table.update_with_items(rows(&[("a", true), ("b", true)]));
+        // Items were already non-empty before this update, so selection stays untouched.
+        assert_eq!(table.info.state.selected(), None);
+    }
+
+    #[test]
+    fn draw_renders_headers_and_selection_marker() {
+        let mut table = TestTable::default();
+        table.update_with_items(rows(&[("alpha", true), ("beta", true), ("gamma", true)]));
+        table.select_row(0);
+
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| table.draw(f, f.area()).unwrap()).unwrap();
+
+        let buffer: &Buffer = terminal.backend().buffer();
+        let content: String = buffer.content.iter().map(|c| c.symbol()).collect();
+
+        assert!(content.contains("Label"));
+        assert!(content.contains(" ● "));
+        // 3 visible rows -> last row's height is not recorded.
+        assert_eq!(table.info.row_heights.len(), 2);
     }
 }

--- a/src/ui/volume_table.rs
+++ b/src/ui/volume_table.rs
@@ -1,26 +1,19 @@
 use bollard::secret::Volume;
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
-use ratatui::{
-    layout::{Constraint, Rect}, style::{Style, Stylize}, text::Text, widgets::{Cell, HighlightSpacing, Row, Table}, Frame
-};
+use ratatui::layout::Constraint;
 use regex::Regex;
 
 use crate::{
-    event::AppEvent, ui::{common::{render_footer, TableStyle}, resource_table::{ResourceTable, ResourceTableInfo}}
+    event::AppEvent,
+    ui::resource_table::{KeyOutcome, ResourceRow, ResourceTable, ResourceTableInfo},
 };
 
-const ROW_HEIGHT: usize = 3;
-const REFRESH_AFTER_TICK: u8 = 10;
 const REGEX_VOLUME_IN_USE: &str = r"\[([a-z0-9]+)\]";
-const DEFAULT_FOOTER: &str = " <Del/D> remove | <F> force remove";
 
 #[derive(Default)]
 pub struct VolumeTable {
-    style: TableStyle,
-    skipped_tick_count_for_refresh: u8,
     info: ResourceTableInfo<VolumeTableRow>,
-    err: Option<String>,
 }
 
 #[derive(Default)]
@@ -33,126 +26,100 @@ pub struct VolumeTableRow {
 impl ResourceTable for VolumeTable {
     type RowType = VolumeTableRow;
 
-    fn get_table_info(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
+    const HEADERS: &'static [&'static str] = &["Name", "Driver", "Created At"];
+    const WIDTHS: &'static [Constraint] = &[
+        Constraint::Min(30),
+        Constraint::Min(0),
+        Constraint::Length(27),
+    ];
+    const DEFAULT_FOOTER: &'static str = " <Del/D> remove | <F> force remove";
+
+    fn table_info(&self) -> &ResourceTableInfo<Self::RowType> {
+        &self.info
+    }
+
+    fn table_info_mut(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
         &mut self.info
     }
 
-    fn render_table(&mut self, frame: &mut Frame, area: Rect) {
-        let header = ["Name", "Driver", "Created At"].into_iter()
-            .map(Cell::from)
-            .collect::<Row>()
-            .style(self.style.header_style)
-            .height(1);
-
-        self.info.row_heights.clear();
-
-        let rows = self.info.items.iter().enumerate().map(|(index, volume)| {
-            let row_style = if index % 2 == 0 { self.style.row_style } else { self.style.alt_row_style };
-            let item = volume.ref_array();
-
-            if index < self.info.items.len() - 1 {
-                self.info.row_heights.push(ROW_HEIGHT);
-            }
-
-            item.into_iter()
-                .map(|content| Cell::from(Text::from(format!("\n{content}\n"))))
-                .collect::<Row>()
-                .style(row_style)
-                .height(ROW_HEIGHT as u16)
-        });
-
-        let widths = vec![
-            Constraint::Min(30),
-            Constraint::Min(0),
-            Constraint::Length(27),
-        ];
-
-        let table = Table::new(rows, widths)
-            .header(header)
-            .row_highlight_style(self.style.selected_row_style)
-            .highlight_symbol(Text::from(vec!["".into(), " ● ".into()]))
-            .highlight_spacing(HighlightSpacing::Always);
-
-        frame.render_stateful_widget(table, area, &mut self.info.state);
+    fn refresh_event(&self) -> AppEvent {
+        AppEvent::UpdateVolumes
     }
 
-    fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
-        let mut border_style = None;
-        let mut footer_text = DEFAULT_FOOTER.to_string();
-
-        if let Some(err) = &self.err {
-            border_style = Some(Style::new().red());
-            footer_text = err.clone();
-        }
-
-        render_footer(frame, area, footer_text, border_style);
-    }
-}
-
-impl VolumeTable {
-    pub fn handle_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
-        if self.err.is_some() {
-            self.err = None;
-            return Ok(None);
-        }
-
-        let event = match key_event.code {
-            KeyCode::Delete | KeyCode::Char('d') => {
-                self.get_selected_row().map(|volume| AppEvent::RemoveVolume(volume.name.clone(), false))
-            }
-            KeyCode::Char('f') => {
-                self.get_selected_row().map(|volume| AppEvent::RemoveVolume(volume.name.clone(), true))
-            }
-            _ => self.handle_nav_key_event(key_event)?
+    fn handle_resource_key_event(&mut self, key_event: KeyEvent) -> Result<KeyOutcome> {
+        let outcome = match key_event.code {
+            KeyCode::Delete | KeyCode::Char('d') => KeyOutcome::Handled(
+                self.selected_row()
+                    .map(|v| AppEvent::RemoveVolume(v.name.clone(), false)),
+            ),
+            KeyCode::Char('f') => KeyOutcome::Handled(
+                self.selected_row()
+                    .map(|v| AppEvent::RemoveVolume(v.name.clone(), true)),
+            ),
+            _ => KeyOutcome::Fallthrough,
         };
 
-        Ok(event)
+        Ok(outcome)
     }
 
-    pub fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        self.draw_default(frame, area)
-    }
-
-    pub fn tick(&mut self) -> Result<Option<AppEvent>> {
-        if self.skipped_tick_count_for_refresh <= REFRESH_AFTER_TICK {
-            self.skipped_tick_count_for_refresh += 1;
-            return Ok(None);
-        }
-
-        self.skipped_tick_count_for_refresh = 0;
-        Ok(Some(AppEvent::UpdateVolumes))
-    }
-
-    pub fn show_remove_volume_err(&mut self, err: String) {
-        let err_msg = Regex::new(REGEX_VOLUME_IN_USE).ok()
-            .and_then(|re| re.captures(&err))
+    fn error_message(&self, raw: &str) -> String {
+        Regex::new(REGEX_VOLUME_IN_USE)
+            .ok()
+            .and_then(|re| re.captures(raw))
             .and_then(|caps| caps.get(1))
             .map(|m| {
                 let id = m.as_str();
-                format!("Volume is in use by container: {}...", id.get(..15).unwrap_or(id))
+                format!(
+                    "Volume is in use by container: {}...",
+                    id.get(..15).unwrap_or(id)
+                )
             })
-            .unwrap_or_else(|| "Something went wrong...".to_string());
-
-        self.err = Some(format!("[ERR] {}", err_msg))
+            .unwrap_or_else(|| "Something went wrong...".to_string())
     }
 }
 
-impl VolumeTableRow {
-    const fn ref_array(&self) -> [&String; 3] {
-        [&self.name, &self.driver, &self.created_at]
-    }
+impl ResourceRow for VolumeTableRow {
+    type Source = Volume;
 
-    pub fn from_list(volumes: Vec<Volume>) -> Vec<Self> {
-        let mut result = volumes.iter().map(Self::from).collect::<Vec<Self>>();
-        result.sort_by_key(|v| v.name.clone());
-        result
-    }
-
-    fn from(volume: &Volume) -> Self {
+    fn from_source(volume: &Self::Source) -> Self {
         Self {
             name: volume.name.clone(),
             driver: volume.driver.clone(),
             created_at: volume.created_at.as_deref().unwrap_or_default().to_string(),
         }
+    }
+
+    fn cells(&self) -> Vec<String> {
+        vec![
+            self.name.clone(),
+            self.driver.clone(),
+            self.created_at.clone(),
+        ]
+    }
+
+    fn sort_rows(rows: &mut Vec<Self>) {
+        rows.sort_by_key(|v| v.name.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn volume(name: &str) -> Volume {
+        Volume {
+            name: name.to_string(),
+            driver: "local".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn from_list_sorts_by_name() {
+        let volumes = vec![volume("charlie"), volume("alpha"), volume("bravo")];
+        let rows = VolumeTableRow::from_list(volumes);
+        let names: Vec<String> = rows.iter().map(|r| r.name.clone()).collect();
+
+        assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
     }
 }


### PR DESCRIPTION
## Summary

Resolves the heavy duplication across the four resource table implementations (`container_table`, `volume_table`, `network_table`, `image_table`) by pushing the shared skeleton into the `ResourceTable` trait:

- **`ResourceTable` trait** now provides the full render skeleton (header building, zebra striping, `row_heights` bookkeeping, highlight symbol, stateful render, scrollbar), footer + error display, tick-based refresh, key dispatch, and navigation. A concrete table only declares `HEADERS`, `WIDTHS`, `DEFAULT_FOOTER`, refresh event, resource-specific key mapping, and error parsing, plus optional hooks (`is_row_visible`, `footer_text`, `after_draw`) used by the container table for filtering and its dynamic footer.
- **New `ResourceRow` trait** unifies row projection: `from_source`, `cells`, `height`, `sort_rows`, and a provided `from_list`. Image sorting moved onto the row via a private `created_epoch` field with the same sort-then-reverse algorithm so tie ordering is preserved.
- **New `RefreshTicker` helper** in `ui::common` replaces the four duplicated `skipped_tick_count_*` counters and the magic number 10 (also used by `container_info_block`).
- **`KeyOutcome` enum** (`Handled`/`Fallthrough`) deliberately preserves the existing Containers-tab quirk where non-character keys are swallowed instead of falling through to navigation.

Behavior is unchanged; the filtered-selection fix from #29 is preserved via a single `visible_indices` resolution path and covered by a regression test.

Closes #20

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — 28/28 pass (11 new tests: RefreshTicker cadence, nav wraparound over filtered rows, scroll math, error-clearing keypress, Handled/Fallthrough dispatch, empty→non-empty selection, TestBackend render smoke test, per-table sort tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt` — applied to touched files
- [x] Manual TUI check against a live Docker daemon (tab switching, filtering with `t`, remove/error footers, multi-line image/port rows, scrollbar tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)