### PR TITLE
test: add automated tests and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,28 @@
-name: Cargo Build
+name: CI
 
 on:
+  push:
+    branches: [main, dev]
   pull_request:
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  check:
+    name: fmt, clippy, build, test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain:
-          - stable
     steps:
       - uses: actions/checkout@v4
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: cargo build --verbose
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Build
+        run: cargo build --verbose
+      - name: Test
+        run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ cargo run --release
 - Add customization options (themes, keybindings, etc.)
 - Improve error handling and user feedback
 - Add more advanced filtering and search features
-- Add tests and CI/CD pipeline
 
 ## Contributing
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::docker::client::DockerClient;
+use crate::docker::client::{DockerApi, DockerClient};
 use crate::event::{AppEvent, Event, EventHandler};
 use crate::ui::container_info_block::{ContainerData, ContainerInfoBlock};
 use crate::ui::container_table::{ContainerTable, ContainerTableRow};
@@ -21,10 +21,10 @@ use ratatui::{
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, FromRepr};
 
-pub struct App {
+pub struct App<C: DockerApi> {
     running: bool,
     events: EventHandler,
-    docker_client: DockerClient,
+    docker_client: C,
     selected_tab: SelectedTab,
     container_table: ContainerTable,
     container_info: Option<Box<dyn ScrollableInfoBlock<Data = ContainerData>>>,
@@ -33,7 +33,7 @@ pub struct App {
     image_table: ImageTable,
 }
 
-impl App {
+impl App<DockerClient> {
     pub fn new() -> Result<Self> {
         Ok(Self {
             running: true,
@@ -46,6 +46,26 @@ impl App {
             network_table: NetworkTable::default(),
             image_table: ImageTable::default(),
         })
+    }
+}
+
+impl<C: DockerApi> App<C> {
+    /// Test-only constructor; builds an `App` from a caller-provided `DockerApi`
+    /// implementation, using the event handler's test constructor so no crossterm
+    /// reader task is spawned.
+    #[cfg(test)]
+    fn with_client(docker_client: C) -> Self {
+        Self {
+            running: true,
+            events: EventHandler::new_without_reader(),
+            docker_client,
+            selected_tab: SelectedTab::default(),
+            container_table: ContainerTable::default(),
+            container_info: None,
+            volume_table: VolumeTable::default(),
+            network_table: NetworkTable::default(),
+            image_table: ImageTable::default(),
+        }
     }
 
     pub async fn run(mut self, mut terminal: DefaultTerminal) -> Result<()> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -342,3 +342,381 @@ impl SelectedTab {
         Self::from_repr(previous_index).unwrap_or(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bollard::secret::{
+        ContainerInspectResponse, ContainerSummary, ImageSummary, Network, Volume,
+        VolumeListResponse,
+    };
+    use color_eyre::eyre::eyre;
+    use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct MockDockerClient {
+        containers: Vec<ContainerSummary>,
+        volumes: Vec<Volume>,
+        networks: Vec<Network>,
+        images: Vec<ImageSummary>,
+        inspect: Option<ContainerInspectResponse>,
+        fail_with: Option<String>,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl MockDockerClient {
+        fn record(&self, call: impl Into<String>) {
+            self.calls.lock().unwrap().push(call.into());
+        }
+    }
+
+    impl DockerApi for MockDockerClient {
+        async fn list_containers(&self) -> Result<Vec<ContainerSummary>> {
+            self.record("list_containers");
+            Ok(self.containers.clone())
+        }
+
+        async fn stop_container(&self, container_id: &str) -> Result<()> {
+            self.record(format!("stop_container:{container_id}"));
+            match &self.fail_with {
+                Some(msg) => Err(eyre!(msg.clone())),
+                None => Ok(()),
+            }
+        }
+
+        async fn restart_container(&self, container_id: &str) -> Result<()> {
+            self.record(format!("restart_container:{container_id}"));
+            match &self.fail_with {
+                Some(msg) => Err(eyre!(msg.clone())),
+                None => Ok(()),
+            }
+        }
+
+        async fn kill_container(&self, container_id: &str) -> Result<()> {
+            self.record(format!("kill_container:{container_id}"));
+            match &self.fail_with {
+                Some(msg) => Err(eyre!(msg.clone())),
+                None => Ok(()),
+            }
+        }
+
+        async fn remove_container(&self, container_id: &str) -> Result<()> {
+            self.record(format!("remove_container:{container_id}"));
+            match &self.fail_with {
+                Some(msg) => Err(eyre!(msg.clone())),
+                None => Ok(()),
+            }
+        }
+
+        async fn inspect_container(&self, container_id: &str) -> Result<ContainerInspectResponse> {
+            self.record(format!("inspect_container:{container_id}"));
+            self.inspect
+                .clone()
+                .ok_or_else(|| eyre!("no inspect data configured"))
+        }
+
+        async fn list_volumes(&self) -> Result<VolumeListResponse> {
+            self.record("list_volumes");
+            Ok(VolumeListResponse {
+                volumes: Some(self.volumes.clone()),
+                ..Default::default()
+            })
+        }
+
+        async fn remove_volume(&self, name: &str, force: bool) -> Result<()> {
+            self.record(format!("remove_volume:{name}:{force}"));
+            match &self.fail_with {
+                Some(msg) => Err(eyre!(msg.clone())),
+                None => Ok(()),
+            }
+        }
+
+        async fn list_networks(&self) -> Result<Vec<Network>> {
+            self.record("list_networks");
+            Ok(self.networks.clone())
+        }
+
+        async fn remove_network(&self, name: &str) -> Result<()> {
+            self.record(format!("remove_network:{name}"));
+            match &self.fail_with {
+                Some(msg) => Err(eyre!(msg.clone())),
+                None => Ok(()),
+            }
+        }
+
+        async fn list_images(&self) -> Result<Vec<ImageSummary>> {
+            self.record("list_images");
+            Ok(self.images.clone())
+        }
+
+        async fn remove_image(&self, id: &str, force: bool) -> Result<()> {
+            self.record(format!("remove_image:{id}:{force}"));
+            match &self.fail_with {
+                Some(msg) => Err(eyre!(msg.clone())),
+                None => Ok(()),
+            }
+        }
+    }
+
+    fn container_summary(id: &str) -> ContainerSummary {
+        ContainerSummary {
+            id: Some(id.to_string()),
+            names: Some(vec![format!("/{id}")]),
+            state: Some("running".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn volume(name: &str) -> Volume {
+        Volume {
+            name: name.to_string(),
+            driver: "local".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn network(id: &str, name: &str) -> Network {
+        Network {
+            id: Some(id.to_string()),
+            name: Some(name.to_string()),
+            driver: Some("bridge".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn image(id: &str) -> ImageSummary {
+        ImageSummary {
+            id: format!("sha256:{id}"),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn update_containers_populates_table() {
+        let mock = MockDockerClient {
+            containers: vec![container_summary("a"), container_summary("b")],
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.update_containers().await.unwrap();
+
+        assert_eq!(app.container_table.table_info().items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn update_volumes_populates_table() {
+        let mock = MockDockerClient {
+            volumes: vec![volume("a"), volume("b")],
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.update_volumes().await.unwrap();
+
+        assert_eq!(app.volume_table.table_info().items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn update_networks_populates_table() {
+        let mock = MockDockerClient {
+            networks: vec![network("111111111111", "a"), network("222222222222", "b")],
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.update_networks().await.unwrap();
+
+        assert_eq!(app.network_table.table_info().items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn update_images_populates_table() {
+        let mock = MockDockerClient {
+            images: vec![
+                image("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"),
+                image("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abce"),
+            ],
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.update_images().await.unwrap();
+
+        assert_eq!(app.image_table.table_info().items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn restart_container_error_is_shown_in_footer() {
+        let mock = MockDockerClient {
+            fail_with: Some("a:b:daemon says no".to_string()),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.restart_container("container-id".to_string())
+            .await
+            .unwrap();
+
+        let err = app.container_table.table_info().err.clone().unwrap();
+        assert!(err.starts_with("[ERR] "));
+        assert!(err.contains("daemon says no"));
+    }
+
+    #[tokio::test]
+    async fn remove_volume_error_is_shown_in_footer() {
+        let mock = MockDockerClient {
+            fail_with: Some("volume is in use by container [abc123def456]".to_string()),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.remove_volume("volume-name".to_string(), false)
+            .await
+            .unwrap();
+
+        let err = app.volume_table.table_info().err.clone().unwrap();
+        assert!(err.starts_with("[ERR] "));
+        assert!(err.contains("Volume is in use by container: abc123def456"));
+    }
+
+    #[tokio::test]
+    async fn remove_network_error_is_shown_in_footer() {
+        let mock = MockDockerClient {
+            fail_with: Some("a:b:daemon says no".to_string()),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.remove_network("network-name".to_string())
+            .await
+            .unwrap();
+
+        let err = app.network_table.table_info().err.clone().unwrap();
+        assert!(err.starts_with("[ERR] "));
+        assert!(err.contains("daemon says no"));
+    }
+
+    #[tokio::test]
+    async fn go_to_container_info_opens_and_back_closes() {
+        let mock = MockDockerClient {
+            inspect: Some(ContainerInspectResponse {
+                id: Some("container-id".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.go_to_container_info("container-id".to_string())
+            .await
+            .unwrap();
+        assert!(app.container_info.is_some());
+
+        let event = app.handle_key_event(KeyEvent::from(KeyCode::Esc)).unwrap();
+        assert!(matches!(event, Some(AppEvent::Back)));
+    }
+
+    #[tokio::test]
+    async fn key_events_route_to_info_block_when_open() {
+        let mock = MockDockerClient {
+            inspect: Some(ContainerInspectResponse {
+                id: Some("container-id".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.go_to_container_info("container-id".to_string())
+            .await
+            .unwrap();
+
+        let tab_before = app.selected_tab as usize;
+        app.handle_key_event(KeyEvent::from(KeyCode::Char('t')))
+            .unwrap();
+        assert_eq!(app.selected_tab as usize, tab_before);
+    }
+
+    #[test]
+    fn ctrl_c_quits() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        let event = app
+            .handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::Quit)));
+
+        app.quit();
+        assert!(!app.running);
+    }
+
+    #[test]
+    fn arrow_and_hjkl_change_tabs() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        assert_eq!(app.selected_tab as usize, SelectedTab::Containers as usize);
+
+        app.handle_key_event(KeyEvent::from(KeyCode::Right))
+            .unwrap();
+        assert_eq!(app.selected_tab as usize, SelectedTab::Volumes as usize);
+
+        app.handle_key_event(KeyEvent::from(KeyCode::Char('l')))
+            .unwrap();
+        assert_eq!(app.selected_tab as usize, SelectedTab::Networks as usize);
+
+        app.handle_key_event(KeyEvent::from(KeyCode::Left)).unwrap();
+        assert_eq!(app.selected_tab as usize, SelectedTab::Volumes as usize);
+
+        app.handle_key_event(KeyEvent::from(KeyCode::Char('h')))
+            .unwrap();
+        assert_eq!(app.selected_tab as usize, SelectedTab::Containers as usize);
+
+        // Saturates at the low end.
+        app.handle_key_event(KeyEvent::from(KeyCode::Left)).unwrap();
+        assert_eq!(app.selected_tab as usize, SelectedTab::Containers as usize);
+
+        // Saturates at the high end.
+        for _ in 0..5 {
+            app.handle_key_event(KeyEvent::from(KeyCode::Right))
+                .unwrap();
+        }
+        assert_eq!(app.selected_tab as usize, SelectedTab::Images as usize);
+    }
+
+    #[test]
+    fn selected_tab_next_and_previous_saturate() {
+        assert_eq!(SelectedTab::Containers.previous() as usize, 0);
+        assert_eq!(
+            SelectedTab::Containers.next() as usize,
+            SelectedTab::Volumes as usize
+        );
+        assert_eq!(
+            SelectedTab::Volumes.next() as usize,
+            SelectedTab::Networks as usize
+        );
+        assert_eq!(
+            SelectedTab::Networks.next() as usize,
+            SelectedTab::Images as usize
+        );
+        assert_eq!(
+            SelectedTab::Images.next() as usize,
+            SelectedTab::Images as usize
+        );
+        assert_eq!(
+            SelectedTab::Volumes.previous() as usize,
+            SelectedTab::Containers as usize
+        );
+    }
+
+    #[test]
+    fn selected_tab_title_renders_padded_name() {
+        assert_eq!(
+            SelectedTab::Containers.title().to_string(),
+            "  Containers  "
+        );
+    }
+}

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -21,8 +21,28 @@ impl DockerClient {
             client: Docker::connect_with_local_defaults()?,
         })
     }
+}
 
-    pub async fn list_containers(&self) -> Result<Vec<ContainerSummary>> {
+/// Crate-internal trait, App is awaited directly by #[tokio::main] and never
+/// tokio::spawn-ed, so no Send bound is required.
+#[allow(async_fn_in_trait)]
+pub trait DockerApi {
+    async fn list_containers(&self) -> Result<Vec<ContainerSummary>>;
+    async fn stop_container(&self, container_id: &str) -> Result<()>;
+    async fn restart_container(&self, container_id: &str) -> Result<()>;
+    async fn kill_container(&self, container_id: &str) -> Result<()>;
+    async fn remove_container(&self, container_id: &str) -> Result<()>;
+    async fn inspect_container(&self, container_id: &str) -> Result<ContainerInspectResponse>;
+    async fn list_volumes(&self) -> Result<VolumeListResponse>;
+    async fn remove_volume(&self, name: &str, force: bool) -> Result<()>;
+    async fn list_networks(&self) -> Result<Vec<Network>>;
+    async fn remove_network(&self, name: &str) -> Result<()>;
+    async fn list_images(&self) -> Result<Vec<ImageSummary>>;
+    async fn remove_image(&self, id: &str, force: bool) -> Result<()>;
+}
+
+impl DockerApi for DockerClient {
+    async fn list_containers(&self) -> Result<Vec<ContainerSummary>> {
         Ok(self
             .client
             .list_containers(Some(ListContainersOptions::<String> {
@@ -32,28 +52,28 @@ impl DockerClient {
             .await?)
     }
 
-    pub async fn stop_container(&self, container_id: &str) -> Result<()> {
+    async fn stop_container(&self, container_id: &str) -> Result<()> {
         self.client
             .stop_container(container_id, None::<StopContainerOptions>)
             .await?;
         Ok(())
     }
 
-    pub async fn restart_container(&self, container_id: &str) -> Result<()> {
+    async fn restart_container(&self, container_id: &str) -> Result<()> {
         self.client
             .restart_container(container_id, None::<RestartContainerOptions>)
             .await?;
         Ok(())
     }
 
-    pub async fn kill_container(&self, container_id: &str) -> Result<()> {
+    async fn kill_container(&self, container_id: &str) -> Result<()> {
         self.client
             .kill_container(container_id, None::<KillContainerOptions<String>>)
             .await?;
         Ok(())
     }
 
-    pub async fn remove_container(&self, container_id: &str) -> Result<()> {
+    async fn remove_container(&self, container_id: &str) -> Result<()> {
         self.client
             .remove_container(
                 container_id,
@@ -66,39 +86,39 @@ impl DockerClient {
         Ok(())
     }
 
-    pub async fn inspect_container(&self, container_id: &str) -> Result<ContainerInspectResponse> {
+    async fn inspect_container(&self, container_id: &str) -> Result<ContainerInspectResponse> {
         Ok(self
             .client
             .inspect_container(container_id, None::<InspectContainerOptions>)
             .await?)
     }
 
-    pub async fn list_volumes(&self) -> Result<VolumeListResponse> {
+    async fn list_volumes(&self) -> Result<VolumeListResponse> {
         Ok(self
             .client
             .list_volumes(Some(ListVolumesOptions::<String>::default()))
             .await?)
     }
 
-    pub async fn remove_volume(&self, name: &str, force: bool) -> Result<()> {
+    async fn remove_volume(&self, name: &str, force: bool) -> Result<()> {
         Ok(self
             .client
             .remove_volume(name, Some(RemoveVolumeOptions { force }))
             .await?)
     }
 
-    pub async fn list_networks(&self) -> Result<Vec<Network>> {
+    async fn list_networks(&self) -> Result<Vec<Network>> {
         Ok(self
             .client
             .list_networks(Some(ListNetworksOptions::<String>::default()))
             .await?)
     }
 
-    pub async fn remove_network(&self, name: &str) -> Result<()> {
+    async fn remove_network(&self, name: &str) -> Result<()> {
         Ok(self.client.remove_network(name).await?)
     }
 
-    pub async fn list_images(&self) -> Result<Vec<ImageSummary>> {
+    async fn list_images(&self) -> Result<Vec<ImageSummary>> {
         let options = Some(ListImagesOptions::<String> {
             all: true,
             ..Default::default()
@@ -106,7 +126,7 @@ impl DockerClient {
         Ok(self.client.list_images(options).await?)
     }
 
-    pub async fn remove_image(&self, id: &str, force: bool) -> Result<()> {
+    async fn remove_image(&self, id: &str, force: bool) -> Result<()> {
         let options = Some(RemoveImageOptions {
             force,
             ..Default::default()

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -74,15 +74,24 @@ impl DockerClient {
     }
 
     pub async fn list_volumes(&self) -> Result<VolumeListResponse> {
-        Ok(self.client.list_volumes(Some(ListVolumesOptions::<String>::default())).await?)
+        Ok(self
+            .client
+            .list_volumes(Some(ListVolumesOptions::<String>::default()))
+            .await?)
     }
 
     pub async fn remove_volume(&self, name: &str, force: bool) -> Result<()> {
-        Ok(self.client.remove_volume(name, Some(RemoveVolumeOptions { force })).await?)
+        Ok(self
+            .client
+            .remove_volume(name, Some(RemoveVolumeOptions { force }))
+            .await?)
     }
 
     pub async fn list_networks(&self) -> Result<Vec<Network>> {
-        Ok(self.client.list_networks(Some(ListNetworksOptions::<String>::default())).await?)
+        Ok(self
+            .client
+            .list_networks(Some(ListNetworksOptions::<String>::default()))
+            .await?)
     }
 
     pub async fn remove_network(&self, name: &str) -> Result<()> {
@@ -90,12 +99,18 @@ impl DockerClient {
     }
 
     pub async fn list_images(&self) -> Result<Vec<ImageSummary>> {
-        let options = Some(ListImagesOptions::<String> { all: true, ..Default::default() });
+        let options = Some(ListImagesOptions::<String> {
+            all: true,
+            ..Default::default()
+        });
         Ok(self.client.list_images(options).await?)
     }
 
     pub async fn remove_image(&self, id: &str, force: bool) -> Result<()> {
-        let options = Some(RemoveImageOptions { force, ..Default::default() });
+        let options = Some(RemoveImageOptions {
+            force,
+            ..Default::default()
+        });
         self.client.remove_image(id, options, None).await?;
         Ok(())
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -57,6 +57,14 @@ impl EventHandler {
     pub fn send(&mut self, app_event: AppEvent) {
         let _ = self.sender.send(Event::App(app_event));
     }
+
+    /// Test-only constructor; skips the crossterm reader task so `App` can be driven
+    /// deterministically without a terminal.
+    #[cfg(test)]
+    pub fn new_without_reader() -> Self {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        Self { sender, receiver }
+    }
 }
 
 struct EventTask {
@@ -94,5 +102,20 @@ impl EventTask {
 
     fn send(&self, event: Event) {
         let _ = self.sender.send(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn send_then_next_returns_the_app_event() {
+        let mut handler = EventHandler::new_without_reader();
+
+        handler.send(AppEvent::Quit);
+
+        let event = handler.next().await.unwrap();
+        assert!(matches!(event, Event::App(AppEvent::Quit)));
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,7 +1,7 @@
 use color_eyre::eyre::{OptionExt, Result};
 use crossterm::event::KeyEventKind;
 use futures::{FutureExt, StreamExt};
-use ratatui::crossterm::event::{KeyEvent, Event::Key};
+use ratatui::crossterm::event::{Event::Key, KeyEvent};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
@@ -48,7 +48,9 @@ impl EventHandler {
     }
 
     pub async fn next(&mut self) -> Result<Event> {
-        self.receiver.recv().await
+        self.receiver
+            .recv()
+            .await
             .ok_or_eyre("Failed to receive event")
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod app;
-mod ui;
 mod docker;
 mod event;
+mod ui;
 mod utils;
 
 use crate::app::App;

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -109,7 +109,11 @@ pub fn time_ago_string(epoch_secs: i64) -> String {
         .as_secs() as i64;
 
     let diff = now - epoch_secs;
-    let abs_diff = diff.abs();
+    format_time_ago(diff)
+}
+
+fn format_time_ago(diff_secs: i64) -> String {
+    let abs_diff = diff_secs.abs();
 
     let (value, unit) = if abs_diff >= 31_536_000 {
         (abs_diff / 31_536_000, "year")
@@ -127,7 +131,7 @@ pub fn time_ago_string(epoch_secs: i64) -> String {
 
     let plural = if value == 1 { "" } else { "s" };
 
-    if diff >= 0 {
+    if diff_secs >= 0 {
         format!("{value} {unit}{plural} ago")
     } else {
         format!("in {value} {unit}{plural}")
@@ -151,5 +155,40 @@ mod tests {
             assert!(!ticker.should_refresh());
         }
         assert!(ticker.should_refresh());
+    }
+
+    #[test]
+    fn format_time_ago_unit_boundaries() {
+        assert_eq!(format_time_ago(59), "59 seconds ago");
+        assert_eq!(format_time_ago(60), "1 minute ago");
+        assert_eq!(format_time_ago(3_600), "1 hour ago");
+        assert_eq!(format_time_ago(86_400), "1 day ago");
+        assert_eq!(format_time_ago(2_592_000), "1 month ago");
+        assert_eq!(format_time_ago(31_536_000), "1 year ago");
+    }
+
+    #[test]
+    fn format_time_ago_plural_vs_singular() {
+        assert_eq!(format_time_ago(120), "2 minutes ago");
+    }
+
+    #[test]
+    fn format_time_ago_zero_diff() {
+        assert_eq!(format_time_ago(0), "0 seconds ago");
+    }
+
+    #[test]
+    fn format_time_ago_negative_diff_is_in_the_future() {
+        assert_eq!(format_time_ago(-300), "in 5 minutes");
+    }
+
+    #[test]
+    fn time_ago_string_smoke_test_for_now() {
+        let now_epoch = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs() as i64;
+
+        assert!(time_ago_string(now_epoch).starts_with("0 second"));
     }
 }

--- a/src/ui/container_info_block.rs
+++ b/src/ui/container_info_block.rs
@@ -431,4 +431,157 @@ mod tests {
         assert!(!lines.iter().any(|l| l.starts_with("Env:")));
         assert!(!lines.iter().any(|l| l.starts_with("Labels:")));
     }
+
+    #[test]
+    fn format_list_returns_none_for_empty_or_blank_entries() {
+        assert!(format_list(vec![]).is_none());
+        assert!(format_list(vec!["".to_string(), "".to_string()]).is_none());
+    }
+
+    #[test]
+    fn format_list_sorts_and_prefixes_entries() {
+        let result = format_list(vec!["charlie".to_string(), "alpha".to_string()]).unwrap();
+        let contents: Vec<String> = result.into_iter().map(|(_, c)| c).collect();
+        assert_eq!(
+            contents,
+            vec![" - alpha".to_string(), " - charlie".to_string()]
+        );
+    }
+
+    #[test]
+    fn get_footer_text_variants() {
+        let running_text = get_footer_text(true);
+        assert!(running_text.contains("<R> restart | <S> stop | <X> kill"));
+        assert!(running_text.contains("<Del/D> remove"));
+
+        let stopped_text = get_footer_text(false);
+        assert!(stopped_text.contains("<R> start"));
+        assert!(stopped_text.contains("<Del/D> remove"));
+    }
+
+    fn container_with_id(id: &str) -> ContainerInspectResponse {
+        ContainerInspectResponse {
+            id: Some(id.to_string()),
+            name: Some(format!("/{id}")),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn handle_key_event_dispatches_resource_actions() {
+        let mut block = ContainerInfoBlock {
+            data: ContainerData::from(container_with_id("container-id")),
+            ..Default::default()
+        };
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Char('d')))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::RemoveContainer(id)) if id == "container-id"));
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Delete))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::RemoveContainer(id)) if id == "container-id"));
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Char('r')))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::RestartContainer(id)) if id == "container-id"));
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Char('s')))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::StopContainer(id)) if id == "container-id"));
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Char('x')))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::KillContainer(id)) if id == "container-id"));
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Char('q')))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::Back)));
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Esc))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::Back)));
+    }
+
+    #[test]
+    fn tick_fires_exactly_once_every_twelve_ticks() {
+        let mut block = ContainerInfoBlock {
+            data: ContainerData::from(container_with_id("container-id")),
+            ..Default::default()
+        };
+
+        let mut fired = 0;
+        for _ in 0..12 {
+            if block.tick().unwrap().is_some() {
+                fired += 1;
+            }
+        }
+
+        assert_eq!(fired, 1);
+    }
+
+    #[test]
+    fn get_content_as_lines_includes_populated_sections_sorted() {
+        let container = ContainerInspectResponse {
+            id: Some("container-id".to_string()),
+            name: Some("/my-container".to_string()),
+            mounts: Some(vec![bollard::secret::MountPoint {
+                typ: Some(bollard::secret::MountPointTypeEnum::VOLUME),
+                name: Some("my-volume".to_string()),
+                destination: Some("/data".to_string()),
+                ..Default::default()
+            }]),
+            config: Some(ContainerConfig {
+                env: Some(vec!["B=2".to_string(), "A=1".to_string()]),
+                labels: Some({
+                    let mut labels = HashMap::new();
+                    labels.insert("z".to_string(), "last".to_string());
+                    labels.insert("a".to_string(), "first".to_string());
+                    labels
+                }),
+                ..Default::default()
+            }),
+            network_settings: Some(bollard::secret::NetworkSettings {
+                ports: Some({
+                    let mut ports = HashMap::new();
+                    ports.insert(
+                        "80/tcp".to_string(),
+                        Some(vec![bollard::secret::PortBinding {
+                            host_ip: Some("0.0.0.0".to_string()),
+                            host_port: Some("8080".to_string()),
+                        }]),
+                    );
+                    ports
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let data = ContainerData::from(container);
+        let lines: Vec<String> = get_content_as_lines(&data)
+            .iter()
+            .map(|l| l.to_string())
+            .collect();
+
+        assert!(lines.iter().any(|l| l.starts_with("Port Configs:")));
+        assert!(lines.iter().any(|l| l.starts_with("Volumes:")));
+        assert!(lines.iter().any(|l| l.starts_with("Env:")));
+        assert!(lines.iter().any(|l| l.starts_with("Labels:")));
+
+        let env_index = lines.iter().position(|l| l.starts_with("Env:")).unwrap();
+        assert!(lines[env_index + 1].contains("A=1"));
+        assert!(lines[env_index + 2].contains("B=2"));
+
+        let labels_index = lines.iter().position(|l| l.starts_with("Labels:")).unwrap();
+        assert!(lines[labels_index + 1].contains("a: first"));
+        assert!(lines[labels_index + 2].contains("z: last"));
+    }
 }

--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -201,6 +201,7 @@ fn get_footer_text(show_all: bool, is_running: Option<bool>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bollard::secret::PortTypeEnum;
 
     fn summary_with_state(state: &str) -> ContainerSummary {
         ContainerSummary {
@@ -261,5 +262,168 @@ mod tests {
         assert_eq!(cells[2], "-"); // image
         assert_eq!(cells[3], "-"); // state (EMPTY)
         assert_eq!(cells[4], "-"); // ports
+    }
+
+    #[test]
+    fn get_footer_text_variants() {
+        let text = get_footer_text(true, None);
+        assert_eq!(text, " <Ent> details | <T> All");
+
+        let text = get_footer_text(true, Some(true));
+        assert!(text.contains("restart | <S> stop | <X> kill"));
+        assert!(text.contains("<T> All"));
+
+        let text = get_footer_text(false, Some(false));
+        assert!(text.contains("<R> start"));
+        assert!(text.contains("<T> Running"));
+    }
+
+    #[test]
+    fn error_message_extracts_third_colon_segment() {
+        let table = ContainerTable::default();
+        assert_eq!(table.error_message("a:b:message"), "message");
+        assert_eq!(table.error_message("a:b"), "Something went wrong...");
+    }
+
+    fn summary_with_ports(id: &str, state: &str) -> ContainerSummary {
+        ContainerSummary {
+            id: Some(id.to_string()),
+            names: Some(vec![format!("/{id}")]),
+            image: Some("image".to_string()),
+            state: Some(state.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn handle_resource_key_event_dispatches_expected_events() {
+        let mut table = ContainerTable::default();
+        let rows = ContainerTableRow::from_list(vec![
+            summary_with_ports("running-id", "running"),
+            summary_with_ports("exited-id", "exited"),
+        ]);
+        table.update_with_items(rows);
+        table.select_row(0);
+
+        let id = table.selected_row().unwrap().id.clone();
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('r')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RestartContainer(got))) => assert_eq!(got, id),
+            _ => panic!("expected RestartContainer"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('s')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::StopContainer(got))) => assert_eq!(got, id),
+            _ => panic!("expected StopContainer"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('x')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::KillContainer(got))) => assert_eq!(got, id),
+            _ => panic!("expected KillContainer"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Enter))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::GoToContainerDetails(got))) => assert_eq!(got, id),
+            _ => panic!("expected GoToContainerDetails"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Delete))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveContainer(got))) => assert_eq!(got, id),
+            _ => panic!("expected RemoveContainer"),
+        }
+    }
+
+    #[test]
+    fn toggle_show_all_shrinks_visible_rows_and_clamps_selection() {
+        let mut table = ContainerTable::default();
+        let rows = ContainerTableRow::from_list(vec![
+            summary_with_ports("running-id", "running"),
+            summary_with_ports("exited-id", "exited"),
+        ]);
+        table.update_with_items(rows);
+        table.info.row_heights = vec![DEFAULT_ROW_HEIGHT];
+
+        assert_eq!(table.visible_indices().len(), 2);
+
+        // Select the last index before toggling, then verify it gets clamped.
+        table.select_row(1);
+
+        table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('t')))
+            .unwrap();
+
+        assert_eq!(table.visible_indices().len(), 1);
+        let selected = table.table_info().state.selected().unwrap();
+        assert!(selected < table.visible_indices().len());
+    }
+
+    #[test]
+    fn height_reflects_port_count() {
+        let no_ports = ContainerTableRow {
+            id: "id".to_string(),
+            name: "name".to_string(),
+            image: "image".to_string(),
+            state: ContainerStateStatusEnum::RUNNING,
+            ports: vec![],
+        };
+        assert_eq!(no_ports.height(), DEFAULT_ROW_HEIGHT);
+
+        let two_ports = ContainerTableRow {
+            ports: vec![
+                PortMapping {
+                    private: 80,
+                    public: 8080,
+                    protocol: PortTypeEnum::TCP,
+                },
+                PortMapping {
+                    private: 443,
+                    public: 8443,
+                    protocol: PortTypeEnum::TCP,
+                },
+            ],
+            ..no_ports
+        };
+        assert_eq!(two_ports.height(), 4);
+    }
+
+    #[test]
+    fn cells_joins_multiple_ports_with_newline() {
+        let row = ContainerTableRow {
+            id: "id".to_string(),
+            name: "name".to_string(),
+            image: "image".to_string(),
+            state: ContainerStateStatusEnum::RUNNING,
+            ports: vec![
+                PortMapping {
+                    private: 80,
+                    public: 8080,
+                    protocol: PortTypeEnum::TCP,
+                },
+                PortMapping {
+                    private: 443,
+                    public: 8443,
+                    protocol: PortTypeEnum::TCP,
+                },
+            ],
+        };
+
+        let cells = row.cells();
+        assert!(cells[4].contains('\n'));
+        assert_eq!(cells[4].matches('\n').count(), 1);
     }
 }

--- a/src/ui/image_table.rs
+++ b/src/ui/image_table.rs
@@ -140,4 +140,89 @@ mod tests {
 
         assert_eq!(ids, vec!["b", "c", "a"]);
     }
+
+    #[test]
+    fn error_message_matches_realistic_daemon_strings() {
+        let table = ImageTable::default();
+
+        let stopped_msg = "Error response from daemon: conflict: unable to delete abc123def456 \
+            (must be forced) - image is being used by stopped container abc123";
+        assert_eq!(
+            table.error_message(stopped_msg),
+            "(must be forced) - image is being used by stopped container abc123"
+        );
+
+        let running_msg = "Error response from daemon: conflict: unable to delete xyz789 \
+            (cannot be forced) - image is being used by running container xyz";
+        assert_eq!(
+            table.error_message(running_msg),
+            "(cannot be forced) - image is being used by running container xyz"
+        );
+
+        assert_eq!(
+            table.error_message("some unrelated error"),
+            "Something went wrong..."
+        );
+    }
+
+    #[test]
+    fn height_reflects_tag_count() {
+        let no_tags = ImageTableRow {
+            id: "id".to_string(),
+            tags: String::new(),
+            size: "0".to_string(),
+            created: "now".to_string(),
+            created_epoch: 0,
+        };
+        assert_eq!(no_tags.height(), DEFAULT_ROW_HEIGHT);
+
+        let two_tags = ImageTableRow {
+            tags: "repo:tag1\nrepo:tag2".to_string(),
+            ..no_tags
+        };
+        assert_eq!(two_tags.height(), 4);
+    }
+
+    #[test]
+    fn handle_resource_key_event_dispatches_expected_events() {
+        let mut table = ImageTable::default();
+        let images = vec![image(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd",
+            100,
+        )];
+        table.update_with_items(ImageTableRow::from_list(images));
+        table.select_row(0);
+        let id = table.selected_row().unwrap().id.clone();
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('d')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveImage(got, false))) => assert_eq!(got, id),
+            _ => panic!("expected RemoveImage(id, false)"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Delete))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveImage(got, false))) => assert_eq!(got, id),
+            _ => panic!("expected RemoveImage(id, false)"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('f')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveImage(got, true))) => assert_eq!(got, id),
+            _ => panic!("expected RemoveImage(id, true)"),
+        }
+
+        assert!(matches!(
+            table
+                .handle_resource_key_event(KeyEvent::from(KeyCode::Char('z')))
+                .unwrap(),
+            KeyOutcome::Fallthrough
+        ));
+    }
 }

--- a/src/ui/info_block.rs
+++ b/src/ui/info_block.rs
@@ -93,3 +93,122 @@ pub trait ScrollableInfoBlock {
         scroll_info.vertical = scroll_info.max_vertical;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct TestBlock {
+        scroll: ScrollInfo,
+    }
+
+    impl ScrollableInfoBlock for TestBlock {
+        type Data = ();
+
+        fn handle_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
+            self.handle_nav_key_event(key_event)
+        }
+
+        fn draw(&mut self, _frame: &mut Frame, _area: Rect) -> Result<()> {
+            Ok(())
+        }
+
+        fn tick(&mut self) -> Result<Option<AppEvent>> {
+            Ok(None)
+        }
+
+        fn update_data(&mut self, _data: Self::Data) {}
+
+        fn get_scroll_info(&mut self) -> &mut ScrollInfo {
+            &mut self.scroll
+        }
+    }
+
+    fn block_with_bounds(max_vertical: usize, max_horizontal: usize) -> TestBlock {
+        TestBlock {
+            scroll: ScrollInfo {
+                max_vertical,
+                max_horizontal,
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn scroll_down_stops_at_max_vertical() {
+        let mut block = block_with_bounds(2, 0);
+        block.scroll_down();
+        block.scroll_down();
+        block.scroll_down();
+        assert_eq!(block.scroll.vertical, 2);
+    }
+
+    #[test]
+    fn scroll_up_clamps_at_zero() {
+        let mut block = block_with_bounds(5, 0);
+        block.scroll_up();
+        assert_eq!(block.scroll.vertical, 0);
+    }
+
+    #[test]
+    fn scroll_right_and_left_clamp() {
+        let mut block = block_with_bounds(0, 2);
+        block.scroll_right();
+        block.scroll_right();
+        block.scroll_right();
+        assert_eq!(block.scroll.horizontal, 2);
+
+        block.scroll_left();
+        block.scroll_left();
+        block.scroll_left();
+        assert_eq!(block.scroll.horizontal, 0);
+    }
+
+    #[test]
+    fn home_and_end_set_horizontal_bounds() {
+        let mut block = block_with_bounds(0, 10);
+        block.scroll.horizontal = 5;
+
+        block
+            .handle_key_event(KeyEvent::from(KeyCode::End))
+            .unwrap();
+        assert_eq!(block.scroll.horizontal, 10);
+
+        block
+            .handle_key_event(KeyEvent::from(KeyCode::Home))
+            .unwrap();
+        assert_eq!(block.scroll.horizontal, 0);
+    }
+
+    #[test]
+    fn page_up_and_page_down_set_vertical_bounds() {
+        let mut block = block_with_bounds(10, 0);
+        block.scroll.vertical = 5;
+
+        block
+            .handle_key_event(KeyEvent::from(KeyCode::PageDown))
+            .unwrap();
+        assert_eq!(block.scroll.vertical, 10);
+
+        block
+            .handle_key_event(KeyEvent::from(KeyCode::PageUp))
+            .unwrap();
+        assert_eq!(block.scroll.vertical, 0);
+    }
+
+    #[test]
+    fn esc_and_q_yield_back_event() {
+        let mut block = TestBlock::default();
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Esc))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::Back)));
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Char('q')))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::Back)));
+    }
+}

--- a/src/ui/network_table.rs
+++ b/src/ui/network_table.rs
@@ -128,4 +128,67 @@ mod tests {
 
         assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
     }
+
+    #[test]
+    fn error_message_captures_daemon_in_use_segment() {
+        let table = NetworkTable::default();
+        let raw = "Error response from daemon: error while removing network: network foo id \
+            abc123def456 has active endpoints";
+        assert_eq!(
+            table.error_message(raw),
+            "network foo id abc123def456 has active endpoints"
+        );
+
+        assert_eq!(
+            table.error_message("no colons here"),
+            "Something went wrong..."
+        );
+    }
+
+    #[test]
+    fn from_source_strips_fractional_seconds_and_truncates_id() {
+        let mut net = network("abcdef012345extra", "my-net");
+        net.created = Some("2024-01-02T03:04:05.123456789Z".to_string());
+
+        let row = NetworkTableRow::from_source(&net);
+        assert_eq!(row.created_at, "2024-01-02T03:04:05Z");
+        assert_eq!(row.id, "abcdef012345...");
+    }
+
+    #[test]
+    fn handle_resource_key_event_dispatches_remove_network() {
+        let mut table = NetworkTable::default();
+        table.update_with_items(NetworkTableRow::from_list(vec![network(
+            "111111111111",
+            "my-net",
+        )]));
+        table.select_row(0);
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Delete))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveNetwork(name))) => {
+                assert_eq!(name, "my-net")
+            }
+            _ => panic!("expected RemoveNetwork via Delete"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('d')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveNetwork(name))) => {
+                assert_eq!(name, "my-net")
+            }
+            _ => panic!("expected RemoveNetwork via 'd'"),
+        }
+
+        assert!(matches!(
+            table
+                .handle_resource_key_event(KeyEvent::from(KeyCode::Char('z')))
+                .unwrap(),
+            KeyOutcome::Fallthrough
+        ));
+    }
 }

--- a/src/ui/volume_table.rs
+++ b/src/ui/volume_table.rs
@@ -122,4 +122,54 @@ mod tests {
 
         assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
     }
+
+    #[test]
+    fn error_message_truncates_long_container_id_to_fifteen_chars() {
+        let table = VolumeTable::default();
+        let msg = table.error_message("volume is in use by container [abcdef0123456789abc]");
+        assert_eq!(msg, "Volume is in use by container: abcdef012345678...");
+    }
+
+    #[test]
+    fn error_message_leaves_short_container_id_untruncated() {
+        let table = VolumeTable::default();
+        let msg = table.error_message("volume is in use by container [abc123]");
+        assert_eq!(msg, "Volume is in use by container: abc123...");
+    }
+
+    #[test]
+    fn error_message_falls_back_when_no_bracketed_id() {
+        let table = VolumeTable::default();
+        assert_eq!(
+            table.error_message("some unrelated error"),
+            "Something went wrong..."
+        );
+    }
+
+    #[test]
+    fn handle_resource_key_event_dispatches_expected_events() {
+        let mut table = VolumeTable::default();
+        table.update_with_items(VolumeTableRow::from_list(vec![volume("my-volume")]));
+        table.select_row(0);
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('d')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveVolume(name, false))) => {
+                assert_eq!(name, "my-volume")
+            }
+            _ => panic!("expected RemoveVolume(name, false)"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('f')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveVolume(name, true))) => {
+                assert_eq!(name, "my-volume")
+            }
+            _ => panic!("expected RemoveVolume(name, true)"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Implements the test and CI improvements from issue #24:

- **Unit tests for pure logic** — time-ago formatting (`format_time_ago` extracted from `time_ago_string`), footer texts, error-message extraction for all four resource tables, row heights/cells, key-event handling (start/stop/kill/restart/remove, running-only toggle with selection clamping), scroll navigation via a `TestBlock` double, and container info block content/tick behavior.
- **`DockerApi` trait** — the twelve Docker methods moved behind a crate-internal trait; `App` is now generic over `C: DockerApi` (with `main.rs` unchanged), enabling `App` event-handling tests against a `MockDockerClient` without a Docker daemon: table population, error routing to the correct table footer, container-info open/close, tab navigation, and Ctrl+C quit.
- **CI workflow** — `.github/workflows/ci.yml` now runs `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build`, and `cargo test` on pushes to `main`/`dev` and on all PRs, with `Swatinem/rust-cache` caching.
- Applied rustfmt to three previously unformatted files (separate first commit) and removed the completed "Add tests and CI/CD pipeline" TODO from the README.

Test count: 28 → 75, all passing without a Docker daemon or TTY. No new dependencies.

Closes #24

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build`
- [x] `cargo test` — 75 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)