### PR TITLE
ci: rename check job to a single-word name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   check:
-    name: fmt, clippy, build, test
+    name: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Rename the CI job display name from `fmt, clippy, build, test` to `check` so it shows as a single word in GitHub checks.

No changes to the steps themselves.

## Test plan
- [x] CI runs on this PR and the job appears as `check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)