### PR TITLE
fix: consistent error handling via typed DockerError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,7 @@ dependencies = [
  "regex",
  "strum 0.27.1",
  "strum_macros 0.27.1",
+ "thiserror 2.0.12",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ ratatui = "0.30.0"
 regex = "1.11.1"
 strum = "0.27.1"
 strum_macros = "0.27.1"
+thiserror = "2.0"
 tokio = {version = "1.44.2", features = ["full"]}

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use crate::docker::client::{DockerApi, DockerClient};
+use crate::docker::error::{DockerError, DockerResult};
 use crate::event::{AppEvent, Event, EventHandler};
 use crate::ui::container_info_block::{ContainerData, ContainerInfoBlock};
 use crate::ui::container_table::{ContainerTable, ContainerTableRow};
@@ -69,7 +70,7 @@ impl<C: DockerApi> App<C> {
     }
 
     pub async fn run(mut self, mut terminal: DefaultTerminal) -> Result<()> {
-        self.update_containers().await?;
+        self.update_containers().await;
 
         while self.running {
             terminal.draw(|frame| self.draw(frame, frame.area()))?;
@@ -133,19 +134,19 @@ impl<C: DockerApi> App<C> {
             }
             Event::App(app_event) => match app_event {
                 AppEvent::Quit => self.quit(),
-                AppEvent::UpdateContainers => self.update_containers().await?,
-                AppEvent::UpdateContainerInfo(id) => self.update_container_details(id).await?,
-                AppEvent::RestartContainer(id) => self.restart_container(id).await?,
-                AppEvent::StopContainer(id) => self.docker_client.stop_container(&id).await?,
-                AppEvent::KillContainer(id) => self.docker_client.kill_container(&id).await?,
-                AppEvent::RemoveContainer(id) => self.remove_container(id).await?,
-                AppEvent::GoToContainerDetails(id) => self.go_to_container_info(id).await?,
-                AppEvent::UpdateVolumes => self.update_volumes().await?,
-                AppEvent::RemoveVolume(name, force) => self.remove_volume(name, force).await?,
-                AppEvent::UpdateNetworks => self.update_networks().await?,
-                AppEvent::RemoveNetwork(name) => self.remove_network(name).await?,
-                AppEvent::UpdateImages => self.update_images().await?,
-                AppEvent::RemoveImage(id, force) => self.remove_image(id, force).await?,
+                AppEvent::UpdateContainers => self.update_containers().await,
+                AppEvent::UpdateContainerInfo(id) => self.update_container_details(id).await,
+                AppEvent::RestartContainer(id) => self.restart_container(id).await,
+                AppEvent::StopContainer(id) => self.stop_container(id).await,
+                AppEvent::KillContainer(id) => self.kill_container(id).await,
+                AppEvent::RemoveContainer(id) => self.remove_container(id).await,
+                AppEvent::GoToContainerDetails(id) => self.go_to_container_info(id).await,
+                AppEvent::UpdateVolumes => self.update_volumes().await,
+                AppEvent::RemoveVolume(name, force) => self.remove_volume(name, force).await,
+                AppEvent::UpdateNetworks => self.update_networks().await,
+                AppEvent::RemoveNetwork(name) => self.remove_network(name).await,
+                AppEvent::UpdateImages => self.update_images().await,
+                AppEvent::RemoveImage(id, force) => self.remove_image(id, force).await,
                 AppEvent::Back => self.container_info = None,
             },
         }
@@ -189,13 +190,12 @@ impl<C: DockerApi> App<C> {
         self.selected_tab = self.selected_tab.previous()
     }
 
-    async fn go_to_container_info(&mut self, container_id: String) -> Result<()> {
+    async fn go_to_container_info(&mut self, container_id: String) {
         if let Some(data) = self.get_container_data(container_id).await {
             let mut container_info_block = ContainerInfoBlock::default();
             container_info_block.update_data(data);
             self.container_info = Some(Box::new(container_info_block));
         }
-        Ok(())
     }
 
     fn tick(&mut self) -> Result<Option<AppEvent>> {
@@ -217,87 +217,108 @@ impl<C: DockerApi> App<C> {
         self.running = false;
     }
 
-    async fn get_container_data(&self, container_id: String) -> Option<ContainerData> {
-        if let Ok(data) = self.docker_client.inspect_container(&container_id).await {
-            return Some(ContainerData::from(data));
+    fn report_err(&mut self, tab: SelectedTab, err: &DockerError) {
+        match tab {
+            SelectedTab::Containers => self.container_table.show_err(err),
+            SelectedTab::Volumes => self.volume_table.show_err(err),
+            SelectedTab::Networks => self.network_table.show_err(err),
+            SelectedTab::Images => self.image_table.show_err(err),
         }
-        None
     }
 
-    async fn update_container_details(&mut self, container_id: String) -> Result<()> {
-        if let Some(data) = self.get_container_data(container_id).await
-            && let Some(info_block) = self.container_info.as_mut()
-        {
+    /// Unwraps a Docker result, reporting failures into `tab`'s footer.
+    fn ok_or_report<T>(&mut self, tab: SelectedTab, result: DockerResult<T>) -> Option<T> {
+        match result {
+            Ok(value) => Some(value),
+            Err(err) => {
+                self.report_err(tab, &err);
+                None
+            }
+        }
+    }
+
+    async fn get_container_data(&mut self, container_id: String) -> Option<ContainerData> {
+        let result = self.docker_client.inspect_container(&container_id).await;
+        self.ok_or_report(SelectedTab::Containers, result)
+            .map(ContainerData::from)
+    }
+
+    async fn update_container_details(&mut self, container_id: String) {
+        let Some(data) = self.get_container_data(container_id).await else {
+            return;
+        };
+        if let Some(info_block) = self.container_info.as_mut() {
             info_block.update_data(data);
         }
-        Ok(())
     }
 
-    async fn restart_container(&mut self, container_id: String) -> Result<()> {
-        if let Err(e) = self.docker_client.restart_container(&container_id).await {
-            self.container_table.show_err(e.to_string());
-        }
-        Ok(())
+    async fn restart_container(&mut self, container_id: String) {
+        let result = self.docker_client.restart_container(&container_id).await;
+        self.ok_or_report(SelectedTab::Containers, result);
     }
 
-    async fn remove_container(&mut self, container_id: String) -> Result<()> {
-        if let Err(e) = self.docker_client.remove_container(&container_id).await {
-            self.container_table.show_err(e.to_string());
-        }
-        Ok(())
+    async fn stop_container(&mut self, container_id: String) {
+        let result = self.docker_client.stop_container(&container_id).await;
+        self.ok_or_report(SelectedTab::Containers, result);
     }
 
-    async fn update_containers(&mut self) -> Result<()> {
-        if let Ok(result) = self.docker_client.list_containers().await {
+    async fn kill_container(&mut self, container_id: String) {
+        let result = self.docker_client.kill_container(&container_id).await;
+        self.ok_or_report(SelectedTab::Containers, result);
+    }
+
+    async fn remove_container(&mut self, container_id: String) {
+        let result = self.docker_client.remove_container(&container_id).await;
+        self.ok_or_report(SelectedTab::Containers, result);
+    }
+
+    async fn update_containers(&mut self) {
+        let result = self.docker_client.list_containers().await;
+        if let Some(result) = self.ok_or_report(SelectedTab::Containers, result) {
             let containers = ContainerTableRow::from_list(result);
             self.container_table.update_with_items(containers);
         }
-        Ok(())
     }
 
-    async fn update_volumes(&mut self) -> Result<()> {
-        if let Some(result) = self.docker_client.list_volumes().await?.volumes {
-            let volumes = VolumeTableRow::from_list(result);
+    async fn update_volumes(&mut self) {
+        let result = self.docker_client.list_volumes().await;
+        if let Some(response) = self.ok_or_report(SelectedTab::Volumes, result)
+            && let Some(volumes) = response.volumes
+        {
+            let volumes = VolumeTableRow::from_list(volumes);
             self.volume_table.update_with_items(volumes);
         }
-        Ok(())
     }
 
-    async fn update_networks(&mut self) -> Result<()> {
-        if let Ok(result) = self.docker_client.list_networks().await {
+    async fn update_networks(&mut self) {
+        let result = self.docker_client.list_networks().await;
+        if let Some(result) = self.ok_or_report(SelectedTab::Networks, result) {
             let networks = NetworkTableRow::from_list(result);
             self.network_table.update_with_items(networks);
         }
-        Ok(())
     }
 
-    async fn update_images(&mut self) -> Result<()> {
-        if let Ok(result) = self.docker_client.list_images().await {
+    async fn update_images(&mut self) {
+        let result = self.docker_client.list_images().await;
+        if let Some(result) = self.ok_or_report(SelectedTab::Images, result) {
             let images = ImageTableRow::from_list(result);
             self.image_table.update_with_items(images);
         }
-        Ok(())
     }
 
-    async fn remove_volume(&mut self, name: String, force: bool) -> Result<()> {
-        if let Err(e) = self.docker_client.remove_volume(&name, force).await {
-            self.volume_table.show_err(e.to_string());
-        }
-        Ok(())
+    async fn remove_volume(&mut self, name: String, force: bool) {
+        let result = self.docker_client.remove_volume(&name, force).await;
+        self.ok_or_report(SelectedTab::Volumes, result);
     }
 
-    async fn remove_network(&mut self, name: String) -> Result<()> {
-        if let Err(e) = self.docker_client.remove_network(&name).await {
-            self.network_table.show_err(e.to_string());
-        }
-        Ok(())
+    async fn remove_network(&mut self, name: String) {
+        let result = self.docker_client.remove_network(&name).await;
+        self.ok_or_report(SelectedTab::Networks, result);
     }
 
-    async fn remove_image(&mut self, id: String, force: bool) -> Result<()> {
-        if let Err(e) = self.docker_client.remove_image(&id, force).await {
-            self.image_table.show_err(e.to_string());
-        }
-        Ok(())
+    async fn remove_image(&mut self, id: String, force: bool) {
+        let result = self.docker_client.remove_image(&id, force).await;
+        self.ok_or_report(SelectedTab::Images, result);
     }
 }
 
@@ -350,7 +371,6 @@ mod tests {
         ContainerInspectResponse, ContainerSummary, ImageSummary, Network, Volume,
         VolumeListResponse,
     };
-    use color_eyre::eyre::eyre;
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use std::sync::Mutex;
 
@@ -361,7 +381,7 @@ mod tests {
         networks: Vec<Network>,
         images: Vec<ImageSummary>,
         inspect: Option<ContainerInspectResponse>,
-        fail_with: Option<String>,
+        fail_with: Option<DockerError>,
         calls: Mutex<Vec<String>>,
     }
 
@@ -372,88 +392,106 @@ mod tests {
     }
 
     impl DockerApi for MockDockerClient {
-        async fn list_containers(&self) -> Result<Vec<ContainerSummary>> {
+        async fn list_containers(&self) -> DockerResult<Vec<ContainerSummary>> {
             self.record("list_containers");
+            if let Some(e) = &self.fail_with {
+                return Err(e.clone());
+            }
             Ok(self.containers.clone())
         }
 
-        async fn stop_container(&self, container_id: &str) -> Result<()> {
+        async fn stop_container(&self, container_id: &str) -> DockerResult<()> {
             self.record(format!("stop_container:{container_id}"));
             match &self.fail_with {
-                Some(msg) => Err(eyre!(msg.clone())),
+                Some(e) => Err(e.clone()),
                 None => Ok(()),
             }
         }
 
-        async fn restart_container(&self, container_id: &str) -> Result<()> {
+        async fn restart_container(&self, container_id: &str) -> DockerResult<()> {
             self.record(format!("restart_container:{container_id}"));
             match &self.fail_with {
-                Some(msg) => Err(eyre!(msg.clone())),
+                Some(e) => Err(e.clone()),
                 None => Ok(()),
             }
         }
 
-        async fn kill_container(&self, container_id: &str) -> Result<()> {
+        async fn kill_container(&self, container_id: &str) -> DockerResult<()> {
             self.record(format!("kill_container:{container_id}"));
             match &self.fail_with {
-                Some(msg) => Err(eyre!(msg.clone())),
+                Some(e) => Err(e.clone()),
                 None => Ok(()),
             }
         }
 
-        async fn remove_container(&self, container_id: &str) -> Result<()> {
+        async fn remove_container(&self, container_id: &str) -> DockerResult<()> {
             self.record(format!("remove_container:{container_id}"));
             match &self.fail_with {
-                Some(msg) => Err(eyre!(msg.clone())),
+                Some(e) => Err(e.clone()),
                 None => Ok(()),
             }
         }
 
-        async fn inspect_container(&self, container_id: &str) -> Result<ContainerInspectResponse> {
+        async fn inspect_container(
+            &self,
+            container_id: &str,
+        ) -> DockerResult<ContainerInspectResponse> {
             self.record(format!("inspect_container:{container_id}"));
-            self.inspect
-                .clone()
-                .ok_or_else(|| eyre!("no inspect data configured"))
+            if let Some(e) = &self.fail_with {
+                return Err(e.clone());
+            }
+            self.inspect.clone().ok_or_else(|| DockerError::Other {
+                message: "no inspect data configured".to_string(),
+            })
         }
 
-        async fn list_volumes(&self) -> Result<VolumeListResponse> {
+        async fn list_volumes(&self) -> DockerResult<VolumeListResponse> {
             self.record("list_volumes");
+            if let Some(e) = &self.fail_with {
+                return Err(e.clone());
+            }
             Ok(VolumeListResponse {
                 volumes: Some(self.volumes.clone()),
                 ..Default::default()
             })
         }
 
-        async fn remove_volume(&self, name: &str, force: bool) -> Result<()> {
+        async fn remove_volume(&self, name: &str, force: bool) -> DockerResult<()> {
             self.record(format!("remove_volume:{name}:{force}"));
             match &self.fail_with {
-                Some(msg) => Err(eyre!(msg.clone())),
+                Some(e) => Err(e.clone()),
                 None => Ok(()),
             }
         }
 
-        async fn list_networks(&self) -> Result<Vec<Network>> {
+        async fn list_networks(&self) -> DockerResult<Vec<Network>> {
             self.record("list_networks");
+            if let Some(e) = &self.fail_with {
+                return Err(e.clone());
+            }
             Ok(self.networks.clone())
         }
 
-        async fn remove_network(&self, name: &str) -> Result<()> {
+        async fn remove_network(&self, name: &str) -> DockerResult<()> {
             self.record(format!("remove_network:{name}"));
             match &self.fail_with {
-                Some(msg) => Err(eyre!(msg.clone())),
+                Some(e) => Err(e.clone()),
                 None => Ok(()),
             }
         }
 
-        async fn list_images(&self) -> Result<Vec<ImageSummary>> {
+        async fn list_images(&self) -> DockerResult<Vec<ImageSummary>> {
             self.record("list_images");
+            if let Some(e) = &self.fail_with {
+                return Err(e.clone());
+            }
             Ok(self.images.clone())
         }
 
-        async fn remove_image(&self, id: &str, force: bool) -> Result<()> {
+        async fn remove_image(&self, id: &str, force: bool) -> DockerResult<()> {
             self.record(format!("remove_image:{id}:{force}"));
             match &self.fail_with {
-                Some(msg) => Err(eyre!(msg.clone())),
+                Some(e) => Err(e.clone()),
                 None => Ok(()),
             }
         }
@@ -500,7 +538,7 @@ mod tests {
         };
         let mut app = App::with_client(mock);
 
-        app.update_containers().await.unwrap();
+        app.update_containers().await;
 
         assert_eq!(app.container_table.table_info().items.len(), 2);
     }
@@ -513,7 +551,7 @@ mod tests {
         };
         let mut app = App::with_client(mock);
 
-        app.update_volumes().await.unwrap();
+        app.update_volumes().await;
 
         assert_eq!(app.volume_table.table_info().items.len(), 2);
     }
@@ -526,7 +564,7 @@ mod tests {
         };
         let mut app = App::with_client(mock);
 
-        app.update_networks().await.unwrap();
+        app.update_networks().await;
 
         assert_eq!(app.network_table.table_info().items.len(), 2);
     }
@@ -542,7 +580,7 @@ mod tests {
         };
         let mut app = App::with_client(mock);
 
-        app.update_images().await.unwrap();
+        app.update_images().await;
 
         assert_eq!(app.image_table.table_info().items.len(), 2);
     }
@@ -550,52 +588,130 @@ mod tests {
     #[tokio::test]
     async fn restart_container_error_is_shown_in_footer() {
         let mock = MockDockerClient {
-            fail_with: Some("a:b:daemon says no".to_string()),
+            fail_with: Some(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
             ..Default::default()
         };
         let mut app = App::with_client(mock);
 
-        app.restart_container("container-id".to_string())
-            .await
-            .unwrap();
+        app.restart_container("container-id".to_string()).await;
 
         let err = app.container_table.table_info().err.clone().unwrap();
-        assert!(err.starts_with("[ERR] "));
-        assert!(err.contains("daemon says no"));
+        assert_eq!(err, "[ERR] Conflict: daemon says no");
+    }
+
+    #[tokio::test]
+    async fn stop_container_error_is_shown_in_footer() {
+        let mock = MockDockerClient {
+            fail_with: Some(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.stop_container("container-id".to_string()).await;
+
+        let err = app.container_table.table_info().err.clone().unwrap();
+        assert_eq!(err, "[ERR] Conflict: daemon says no");
+    }
+
+    #[tokio::test]
+    async fn kill_container_error_is_shown_in_footer() {
+        let mock = MockDockerClient {
+            fail_with: Some(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.kill_container("container-id".to_string()).await;
+
+        let err = app.container_table.table_info().err.clone().unwrap();
+        assert_eq!(err, "[ERR] Conflict: daemon says no");
     }
 
     #[tokio::test]
     async fn remove_volume_error_is_shown_in_footer() {
         let mock = MockDockerClient {
-            fail_with: Some("volume is in use by container [abc123def456]".to_string()),
+            fail_with: Some(DockerError::Conflict {
+                message: "volume is in use".to_string(),
+            }),
             ..Default::default()
         };
         let mut app = App::with_client(mock);
 
-        app.remove_volume("volume-name".to_string(), false)
-            .await
-            .unwrap();
+        app.remove_volume("volume-name".to_string(), false).await;
 
         let err = app.volume_table.table_info().err.clone().unwrap();
-        assert!(err.starts_with("[ERR] "));
-        assert!(err.contains("Volume is in use by container: abc123def456"));
+        assert_eq!(err, "[ERR] Conflict: volume is in use");
     }
 
     #[tokio::test]
     async fn remove_network_error_is_shown_in_footer() {
         let mock = MockDockerClient {
-            fail_with: Some("a:b:daemon says no".to_string()),
+            fail_with: Some(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
             ..Default::default()
         };
         let mut app = App::with_client(mock);
 
-        app.remove_network("network-name".to_string())
-            .await
-            .unwrap();
+        app.remove_network("network-name".to_string()).await;
 
         let err = app.network_table.table_info().err.clone().unwrap();
-        assert!(err.starts_with("[ERR] "));
-        assert!(err.contains("daemon says no"));
+        assert_eq!(err, "[ERR] Conflict: daemon says no");
+    }
+
+    #[tokio::test]
+    async fn remove_image_error_is_shown_in_footer() {
+        let mock = MockDockerClient {
+            fail_with: Some(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.remove_image("image-id".to_string(), false).await;
+
+        let err = app.image_table.table_info().err.clone().unwrap();
+        assert_eq!(err, "[ERR] Conflict: daemon says no");
+    }
+
+    #[tokio::test]
+    async fn list_failure_shows_error_on_owning_tab() {
+        let mock = MockDockerClient {
+            fail_with: Some(DockerError::DaemonUnreachable {
+                details: "connection refused".to_string(),
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+        assert_eq!(app.selected_tab as usize, SelectedTab::Containers as usize);
+
+        app.update_images().await;
+
+        assert!(app.image_table.table_info().err.is_some());
+        assert!(app.container_table.table_info().err.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_failure_keeps_previous_items() {
+        let mock = MockDockerClient {
+            fail_with: Some(DockerError::DaemonUnreachable {
+                details: "connection refused".to_string(),
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.update_containers().await;
+
+        assert_eq!(app.container_table.table_info().items.len(), 0);
+        assert!(app.container_table.table_info().err.is_some());
     }
 
     #[tokio::test]
@@ -609,9 +725,7 @@ mod tests {
         };
         let mut app = App::with_client(mock);
 
-        app.go_to_container_info("container-id".to_string())
-            .await
-            .unwrap();
+        app.go_to_container_info("container-id".to_string()).await;
         assert!(app.container_info.is_some());
 
         let event = app.handle_key_event(KeyEvent::from(KeyCode::Esc)).unwrap();
@@ -629,9 +743,7 @@ mod tests {
         };
         let mut app = App::with_client(mock);
 
-        app.go_to_container_info("container-id".to_string())
-            .await
-            .unwrap();
+        app.go_to_container_info("container-id".to_string()).await;
 
         let tab_before = app.selected_tab as usize;
         app.handle_key_event(KeyEvent::from(KeyCode::Char('t')))

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -10,6 +10,8 @@ use bollard::secret::{ContainerInspectResponse, ImageSummary, Network, VolumeLis
 use bollard::volume::{ListVolumesOptions, RemoveVolumeOptions};
 use color_eyre::eyre::Result;
 
+use crate::docker::error::DockerResult;
+
 #[derive(Clone)]
 pub struct DockerClient {
     client: Docker,
@@ -27,22 +29,23 @@ impl DockerClient {
 /// tokio::spawn-ed, so no Send bound is required.
 #[allow(async_fn_in_trait)]
 pub trait DockerApi {
-    async fn list_containers(&self) -> Result<Vec<ContainerSummary>>;
-    async fn stop_container(&self, container_id: &str) -> Result<()>;
-    async fn restart_container(&self, container_id: &str) -> Result<()>;
-    async fn kill_container(&self, container_id: &str) -> Result<()>;
-    async fn remove_container(&self, container_id: &str) -> Result<()>;
-    async fn inspect_container(&self, container_id: &str) -> Result<ContainerInspectResponse>;
-    async fn list_volumes(&self) -> Result<VolumeListResponse>;
-    async fn remove_volume(&self, name: &str, force: bool) -> Result<()>;
-    async fn list_networks(&self) -> Result<Vec<Network>>;
-    async fn remove_network(&self, name: &str) -> Result<()>;
-    async fn list_images(&self) -> Result<Vec<ImageSummary>>;
-    async fn remove_image(&self, id: &str, force: bool) -> Result<()>;
+    async fn list_containers(&self) -> DockerResult<Vec<ContainerSummary>>;
+    async fn stop_container(&self, container_id: &str) -> DockerResult<()>;
+    async fn restart_container(&self, container_id: &str) -> DockerResult<()>;
+    async fn kill_container(&self, container_id: &str) -> DockerResult<()>;
+    async fn remove_container(&self, container_id: &str) -> DockerResult<()>;
+    async fn inspect_container(&self, container_id: &str)
+    -> DockerResult<ContainerInspectResponse>;
+    async fn list_volumes(&self) -> DockerResult<VolumeListResponse>;
+    async fn remove_volume(&self, name: &str, force: bool) -> DockerResult<()>;
+    async fn list_networks(&self) -> DockerResult<Vec<Network>>;
+    async fn remove_network(&self, name: &str) -> DockerResult<()>;
+    async fn list_images(&self) -> DockerResult<Vec<ImageSummary>>;
+    async fn remove_image(&self, id: &str, force: bool) -> DockerResult<()>;
 }
 
 impl DockerApi for DockerClient {
-    async fn list_containers(&self) -> Result<Vec<ContainerSummary>> {
+    async fn list_containers(&self) -> DockerResult<Vec<ContainerSummary>> {
         Ok(self
             .client
             .list_containers(Some(ListContainersOptions::<String> {
@@ -52,28 +55,28 @@ impl DockerApi for DockerClient {
             .await?)
     }
 
-    async fn stop_container(&self, container_id: &str) -> Result<()> {
+    async fn stop_container(&self, container_id: &str) -> DockerResult<()> {
         self.client
             .stop_container(container_id, None::<StopContainerOptions>)
             .await?;
         Ok(())
     }
 
-    async fn restart_container(&self, container_id: &str) -> Result<()> {
+    async fn restart_container(&self, container_id: &str) -> DockerResult<()> {
         self.client
             .restart_container(container_id, None::<RestartContainerOptions>)
             .await?;
         Ok(())
     }
 
-    async fn kill_container(&self, container_id: &str) -> Result<()> {
+    async fn kill_container(&self, container_id: &str) -> DockerResult<()> {
         self.client
             .kill_container(container_id, None::<KillContainerOptions<String>>)
             .await?;
         Ok(())
     }
 
-    async fn remove_container(&self, container_id: &str) -> Result<()> {
+    async fn remove_container(&self, container_id: &str) -> DockerResult<()> {
         self.client
             .remove_container(
                 container_id,
@@ -86,39 +89,42 @@ impl DockerApi for DockerClient {
         Ok(())
     }
 
-    async fn inspect_container(&self, container_id: &str) -> Result<ContainerInspectResponse> {
+    async fn inspect_container(
+        &self,
+        container_id: &str,
+    ) -> DockerResult<ContainerInspectResponse> {
         Ok(self
             .client
             .inspect_container(container_id, None::<InspectContainerOptions>)
             .await?)
     }
 
-    async fn list_volumes(&self) -> Result<VolumeListResponse> {
+    async fn list_volumes(&self) -> DockerResult<VolumeListResponse> {
         Ok(self
             .client
             .list_volumes(Some(ListVolumesOptions::<String>::default()))
             .await?)
     }
 
-    async fn remove_volume(&self, name: &str, force: bool) -> Result<()> {
+    async fn remove_volume(&self, name: &str, force: bool) -> DockerResult<()> {
         Ok(self
             .client
             .remove_volume(name, Some(RemoveVolumeOptions { force }))
             .await?)
     }
 
-    async fn list_networks(&self) -> Result<Vec<Network>> {
+    async fn list_networks(&self) -> DockerResult<Vec<Network>> {
         Ok(self
             .client
             .list_networks(Some(ListNetworksOptions::<String>::default()))
             .await?)
     }
 
-    async fn remove_network(&self, name: &str) -> Result<()> {
+    async fn remove_network(&self, name: &str) -> DockerResult<()> {
         Ok(self.client.remove_network(name).await?)
     }
 
-    async fn list_images(&self) -> Result<Vec<ImageSummary>> {
+    async fn list_images(&self) -> DockerResult<Vec<ImageSummary>> {
         let options = Some(ListImagesOptions::<String> {
             all: true,
             ..Default::default()
@@ -126,7 +132,7 @@ impl DockerApi for DockerClient {
         Ok(self.client.list_images(options).await?)
     }
 
-    async fn remove_image(&self, id: &str, force: bool) -> Result<()> {
+    async fn remove_image(&self, id: &str, force: bool) -> DockerResult<()> {
         let options = Some(RemoveImageOptions {
             force,
             ..Default::default()

--- a/src/docker/error.rs
+++ b/src/docker/error.rs
@@ -1,0 +1,149 @@
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum DockerError {
+    #[error("Not found: {message}")]
+    NotFound { message: String },
+    #[error("Conflict: {message}")]
+    Conflict { message: String },
+    #[error("Cannot reach the Docker daemon ({details})")]
+    DaemonUnreachable { details: String },
+    #[error("Docker error {status_code}: {message}")]
+    Server { status_code: u16, message: String },
+    #[error("Something went wrong: {message}")]
+    Other { message: String },
+}
+
+pub type DockerResult<T> = std::result::Result<T, DockerError>;
+
+impl From<bollard::errors::Error> for DockerError {
+    fn from(err: bollard::errors::Error) -> Self {
+        match &err {
+            bollard::errors::Error::DockerResponseServerError {
+                status_code: 404,
+                message,
+            } => DockerError::NotFound {
+                message: message.clone(),
+            },
+            bollard::errors::Error::DockerResponseServerError {
+                status_code: 409,
+                message,
+            } => DockerError::Conflict {
+                message: message.clone(),
+            },
+            bollard::errors::Error::DockerResponseServerError {
+                status_code,
+                message,
+            } => DockerError::Server {
+                status_code: *status_code,
+                message: message.clone(),
+            },
+            bollard::errors::Error::SocketNotFoundError(_)
+            | bollard::errors::Error::UnsupportedURISchemeError { .. }
+            | bollard::errors::Error::IOError { .. }
+            | bollard::errors::Error::HyperResponseError { .. }
+            | bollard::errors::Error::RequestTimeoutError => DockerError::DaemonUnreachable {
+                details: err.to_string(),
+            },
+            _ => DockerError::Other {
+                message: err.to_string(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_error_404_maps_to_not_found() {
+        let err = bollard::errors::Error::DockerResponseServerError {
+            status_code: 404,
+            message: "No such volume: foo".into(),
+        };
+        let mapped: DockerError = err.into();
+        assert_eq!(
+            mapped,
+            DockerError::NotFound {
+                message: "No such volume: foo".into()
+            }
+        );
+        assert_eq!(mapped.to_string(), "Not found: No such volume: foo");
+    }
+
+    #[test]
+    fn server_error_409_maps_to_conflict() {
+        let err = bollard::errors::Error::DockerResponseServerError {
+            status_code: 409,
+            message: "remove foo: volume is in use - [abc123def456]".into(),
+        };
+        let mapped: DockerError = err.into();
+        assert_eq!(
+            mapped,
+            DockerError::Conflict {
+                message: "remove foo: volume is in use - [abc123def456]".into()
+            }
+        );
+        assert_eq!(
+            mapped.to_string(),
+            "Conflict: remove foo: volume is in use - [abc123def456]"
+        );
+    }
+
+    #[test]
+    fn other_status_codes_map_to_server() {
+        let err = bollard::errors::Error::DockerResponseServerError {
+            status_code: 500,
+            message: "internal server error".into(),
+        };
+        let mapped: DockerError = err.into();
+        assert_eq!(
+            mapped,
+            DockerError::Server {
+                status_code: 500,
+                message: "internal server error".into()
+            }
+        );
+        assert_eq!(
+            mapped.to_string(),
+            "Docker error 500: internal server error"
+        );
+    }
+
+    #[test]
+    fn socket_not_found_and_timeout_map_to_daemon_unreachable() {
+        let socket_err: DockerError =
+            bollard::errors::Error::SocketNotFoundError("/var/run/docker.sock".into()).into();
+        assert!(matches!(socket_err, DockerError::DaemonUnreachable { .. }));
+        assert!(
+            socket_err
+                .to_string()
+                .starts_with("Cannot reach the Docker daemon (")
+        );
+
+        let timeout_err: DockerError = bollard::errors::Error::RequestTimeoutError.into();
+        assert!(matches!(timeout_err, DockerError::DaemonUnreachable { .. }));
+        assert!(
+            timeout_err
+                .to_string()
+                .starts_with("Cannot reach the Docker daemon (")
+        );
+
+        let io_err: DockerError = bollard::errors::Error::IOError {
+            err: std::io::Error::from(std::io::ErrorKind::ConnectionRefused),
+        }
+        .into();
+        assert!(matches!(io_err, DockerError::DaemonUnreachable { .. }));
+        assert!(
+            io_err
+                .to_string()
+                .starts_with("Cannot reach the Docker daemon (")
+        );
+    }
+
+    #[test]
+    fn unmapped_variants_fall_back_to_other() {
+        let err: DockerError = bollard::errors::Error::APIVersionParseError {}.into();
+        assert!(matches!(err, DockerError::Other { .. }));
+        assert!(err.to_string().starts_with("Something went wrong: "));
+    }
+}

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -1,2 +1,3 @@
 pub mod client;
+pub mod error;
 pub mod models;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,10 @@ use color_eyre::eyre::Result;
 async fn main() -> Result<()> {
     color_eyre::install()?;
     let terminal = ratatui::init();
-    let app = App::new()?;
-    let result = app.run(terminal).await;
+    let result = match App::new() {
+        Ok(app) => app.run(terminal).await,
+        Err(e) => Err(e),
+    };
     ratatui::restore();
     result
 }

--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -106,14 +106,6 @@ impl ResourceTable for ContainerTable {
 
         Ok(outcome)
     }
-
-    fn error_message(&self, raw: &str) -> String {
-        raw.split(":")
-            .collect::<Vec<&str>>()
-            .get(2)
-            .map_or("Something went wrong...", |v| v)
-            .to_string()
-    }
 }
 
 impl ResourceRow for ContainerTableRow {
@@ -276,13 +268,6 @@ mod tests {
         let text = get_footer_text(false, Some(false));
         assert!(text.contains("<R> start"));
         assert!(text.contains("<T> Running"));
-    }
-
-    #[test]
-    fn error_message_extracts_third_colon_segment() {
-        let table = ContainerTable::default();
-        assert_eq!(table.error_message("a:b:message"), "message");
-        assert_eq!(table.error_message("a:b"), "Something went wrong...");
     }
 
     fn summary_with_ports(id: &str, state: &str) -> ContainerSummary {

--- a/src/ui/image_table.rs
+++ b/src/ui/image_table.rs
@@ -2,7 +2,6 @@ use bollard::secret::ImageSummary;
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::layout::Constraint;
-use regex::Regex;
 
 use crate::{
     event::AppEvent,
@@ -13,9 +12,6 @@ use crate::{
         },
     },
 };
-
-const REGEX_DELETE_IMG_ERR: &str =
-    r"\((?:cannot|must) be forced\) - image is being used by (?:running|stopped) container \w+";
 
 #[derive(Default)]
 pub struct ImageTable {
@@ -69,15 +65,6 @@ impl ResourceTable for ImageTable {
         };
 
         Ok(outcome)
-    }
-
-    fn error_message(&self, raw: &str) -> String {
-        Regex::new(REGEX_DELETE_IMG_ERR)
-            .ok()
-            .and_then(|re| re.find(raw))
-            .map(|m| m.as_str())
-            .unwrap_or("Something went wrong...")
-            .to_string()
     }
 }
 
@@ -139,30 +126,6 @@ mod tests {
         let ids: Vec<String> = rows.iter().map(|r| r.id.clone()).collect();
 
         assert_eq!(ids, vec!["b", "c", "a"]);
-    }
-
-    #[test]
-    fn error_message_matches_realistic_daemon_strings() {
-        let table = ImageTable::default();
-
-        let stopped_msg = "Error response from daemon: conflict: unable to delete abc123def456 \
-            (must be forced) - image is being used by stopped container abc123";
-        assert_eq!(
-            table.error_message(stopped_msg),
-            "(must be forced) - image is being used by stopped container abc123"
-        );
-
-        let running_msg = "Error response from daemon: conflict: unable to delete xyz789 \
-            (cannot be forced) - image is being used by running container xyz";
-        assert_eq!(
-            table.error_message(running_msg),
-            "(cannot be forced) - image is being used by running container xyz"
-        );
-
-        assert_eq!(
-            table.error_message("some unrelated error"),
-            "Something went wrong..."
-        );
     }
 
     #[test]

--- a/src/ui/network_table.rs
+++ b/src/ui/network_table.rs
@@ -9,7 +9,6 @@ use crate::{
     ui::resource_table::{KeyOutcome, ResourceRow, ResourceTable, ResourceTableInfo},
 };
 
-const REGEX_NETWORK_IN_USE: &str = r":(?:[^:]+:)?\s*([^\(]+)";
 const REGEX_NETWORK_CREATED_AT: &str = r"\.\d+";
 
 #[derive(Default)]
@@ -59,15 +58,6 @@ impl ResourceTable for NetworkTable {
         };
 
         Ok(outcome)
-    }
-
-    fn error_message(&self, raw: &str) -> String {
-        Regex::new(REGEX_NETWORK_IN_USE)
-            .ok()
-            .and_then(|re| re.captures(raw))
-            .and_then(|caps| caps.get(1))
-            .map(|m| m.as_str().to_string())
-            .unwrap_or_else(|| "Something went wrong...".to_string())
     }
 }
 
@@ -127,22 +117,6 @@ mod tests {
         let names: Vec<String> = rows.iter().map(|r| r.name.clone()).collect();
 
         assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
-    }
-
-    #[test]
-    fn error_message_captures_daemon_in_use_segment() {
-        let table = NetworkTable::default();
-        let raw = "Error response from daemon: error while removing network: network foo id \
-            abc123def456 has active endpoints";
-        assert_eq!(
-            table.error_message(raw),
-            "network foo id abc123def456 has active endpoints"
-        );
-
-        assert_eq!(
-            table.error_message("no colons here"),
-            "Something went wrong..."
-        );
     }
 
     #[test]

--- a/src/ui/resource_table.rs
+++ b/src/ui/resource_table.rs
@@ -9,6 +9,7 @@ use ratatui::{
 };
 
 use crate::{
+    docker::error::DockerError,
     event::AppEvent,
     ui::common::{RefreshTicker, TableStyle, render_scrollbar},
 };
@@ -83,7 +84,6 @@ pub trait ResourceTable {
 
     fn refresh_event(&self) -> AppEvent;
     fn handle_resource_key_event(&mut self, key_event: KeyEvent) -> Result<KeyOutcome>;
-    fn error_message(&self, raw: &str) -> String;
 
     /// Whether the row is currently visible (rendered/navigable). Default: all rows visible.
     #[allow(unused_variables)]
@@ -287,9 +287,8 @@ pub trait ResourceTable {
         }
     }
 
-    fn show_err(&mut self, raw: String) {
-        let msg = self.error_message(&raw);
-        self.table_info_mut().err = Some(format!("[ERR] {}", msg.trim()));
+    fn show_err(&mut self, err: &DockerError) {
+        self.table_info_mut().err = Some(format!("[ERR] {err}"));
     }
 }
 
@@ -349,10 +348,6 @@ mod tests {
                 KeyCode::Char('h') => Ok(KeyOutcome::Handled(None)),
                 _ => Ok(KeyOutcome::Fallthrough),
             }
-        }
-
-        fn error_message(&self, raw: &str) -> String {
-            raw.to_string()
         }
 
         fn is_row_visible(&self, row: &Self::RowType) -> bool {
@@ -426,6 +421,20 @@ mod tests {
             .unwrap();
         assert!(result.is_none());
         assert!(table.info.err.is_none());
+    }
+
+    #[test]
+    fn show_err_formats_typed_error_into_footer() {
+        let mut table = TestTable::default();
+
+        table.show_err(&DockerError::Conflict {
+            message: "network foo has active endpoints".into(),
+        });
+
+        assert_eq!(
+            table.info.err,
+            Some("[ERR] Conflict: network foo has active endpoints".to_string())
+        );
     }
 
     #[test]

--- a/src/ui/volume_table.rs
+++ b/src/ui/volume_table.rs
@@ -2,14 +2,11 @@ use bollard::secret::Volume;
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::layout::Constraint;
-use regex::Regex;
 
 use crate::{
     event::AppEvent,
     ui::resource_table::{KeyOutcome, ResourceRow, ResourceTable, ResourceTableInfo},
 };
-
-const REGEX_VOLUME_IN_USE: &str = r"\[([a-z0-9]+)\]";
 
 #[derive(Default)]
 pub struct VolumeTable {
@@ -61,21 +58,6 @@ impl ResourceTable for VolumeTable {
 
         Ok(outcome)
     }
-
-    fn error_message(&self, raw: &str) -> String {
-        Regex::new(REGEX_VOLUME_IN_USE)
-            .ok()
-            .and_then(|re| re.captures(raw))
-            .and_then(|caps| caps.get(1))
-            .map(|m| {
-                let id = m.as_str();
-                format!(
-                    "Volume is in use by container: {}...",
-                    id.get(..15).unwrap_or(id)
-                )
-            })
-            .unwrap_or_else(|| "Something went wrong...".to_string())
-    }
 }
 
 impl ResourceRow for VolumeTableRow {
@@ -121,29 +103,6 @@ mod tests {
         let names: Vec<String> = rows.iter().map(|r| r.name.clone()).collect();
 
         assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
-    }
-
-    #[test]
-    fn error_message_truncates_long_container_id_to_fifteen_chars() {
-        let table = VolumeTable::default();
-        let msg = table.error_message("volume is in use by container [abcdef0123456789abc]");
-        assert_eq!(msg, "Volume is in use by container: abcdef012345678...");
-    }
-
-    #[test]
-    fn error_message_leaves_short_container_id_untruncated() {
-        let table = VolumeTable::default();
-        let msg = table.error_message("volume is in use by container [abc123]");
-        assert_eq!(msg, "Volume is in use by container: abc123...");
-    }
-
-    #[test]
-    fn error_message_falls_back_when_no_bracketed_id() {
-        let table = VolumeTable::default();
-        assert_eq!(
-            table.error_message("some unrelated error"),
-            "Something went wrong..."
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the inconsistent error handling described in #19:

- **No more silent swallowing:** `update_containers` / `update_networks` / `update_images` previously dropped list errors with `if let Ok(...)` — the UI froze with stale data and no feedback. All list refresh failures now surface in the owning tab's footer.
- **No more crashes:** `update_volumes` and the `StopContainer` / `KillContainer` events propagated errors with `?`, taking down the whole app. They now flow through the same footer path as restart/remove.
- **No more fragile string parsing:** the per-table `error_message` implementations (`split(':')` in the container table, regexes in the volume/network/image tables) are removed. A new typed `DockerError` (src/docker/error.rs) is mapped from bollard errors by HTTP status code and error kind (404 → NotFound, 409 → Conflict, socket/IO/timeout → DaemonUnreachable, ...) at the client boundary, and its `Display` impl is the single user-facing message formatter.
- `DockerApi` now returns `DockerResult<T>`; `App`'s docker-touching methods return `()` so a Docker failure is structurally non-fatal. Errors are reported to the tab that owns the operation (not whatever tab is currently visible).
- Bonus: `main` now calls `ratatui::restore()` even when `App::new()` fails, so the terminal is no longer left in raw mode.

## Test plan

- New unit tests for the bollard → `DockerError` mapping (status codes, daemon-unreachable kinds, fallback).
- App-level tests with the mock client: stop/kill/remove failures show in the footer; a failing list refresh sets the error on the owning tab and does not panic.
- Removed tests that asserted the old string-parsing behavior; updated the rest to the typed error.
- `cargo fmt`, `cargo clippy -- -D warnings`, `cargo build`, `cargo test` (80 passed) all clean.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)