### PR TITLE
feat: non-blocking Docker operations

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use crate::docker::client::{DockerApi, DockerClient};
 use crate::docker::error::{DockerError, DockerResult};
-use crate::event::{AppEvent, Event, EventHandler};
+use crate::event::{AppEvent, DockerOutcome, Event, EventHandler, ResourceKind};
 use crate::ui::container_info_block::{ContainerData, ContainerInfoBlock};
 use crate::ui::container_table::{ContainerTable, ContainerTableRow};
 use crate::ui::image_table::{ImageTable, ImageTableRow};
@@ -19,6 +19,7 @@ use ratatui::{
     DefaultTerminal,
     crossterm::event::{KeyCode, KeyEvent, KeyModifiers},
 };
+use std::future::Future;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, FromRepr};
 
@@ -32,6 +33,19 @@ pub struct App<C: DockerApi> {
     volume_table: VolumeTable,
     network_table: NetworkTable,
     image_table: ImageTable,
+    pending: PendingRefreshes,
+    details_requested: bool,
+}
+
+/// Tracks in-flight list requests so `App` never has more than one outstanding
+/// refresh per resource kind at a time.
+#[derive(Default)]
+struct PendingRefreshes {
+    containers: bool,
+    volumes: bool,
+    networks: bool,
+    images: bool,
+    container_info: bool,
 }
 
 impl App<DockerClient> {
@@ -46,6 +60,8 @@ impl App<DockerClient> {
             volume_table: VolumeTable::default(),
             network_table: NetworkTable::default(),
             image_table: ImageTable::default(),
+            pending: PendingRefreshes::default(),
+            details_requested: false,
         })
     }
 }
@@ -66,11 +82,13 @@ impl<C: DockerApi> App<C> {
             volume_table: VolumeTable::default(),
             network_table: NetworkTable::default(),
             image_table: ImageTable::default(),
+            pending: PendingRefreshes::default(),
+            details_requested: false,
         }
     }
 
     pub async fn run(mut self, mut terminal: DefaultTerminal) -> Result<()> {
-        self.update_containers().await;
+        self.request_containers();
 
         while self.running {
             terminal.draw(|frame| self.draw(frame, frame.area()))?;
@@ -132,22 +150,26 @@ impl<C: DockerApi> App<C> {
                     self.events.send(event);
                 }
             }
+            Event::Docker(outcome) => self.apply_docker_outcome(outcome),
             Event::App(app_event) => match app_event {
                 AppEvent::Quit => self.quit(),
-                AppEvent::UpdateContainers => self.update_containers().await,
-                AppEvent::UpdateContainerInfo(id) => self.update_container_details(id).await,
-                AppEvent::RestartContainer(id) => self.restart_container(id).await,
-                AppEvent::StopContainer(id) => self.stop_container(id).await,
-                AppEvent::KillContainer(id) => self.kill_container(id).await,
-                AppEvent::RemoveContainer(id) => self.remove_container(id).await,
-                AppEvent::GoToContainerDetails(id) => self.go_to_container_info(id).await,
-                AppEvent::UpdateVolumes => self.update_volumes().await,
-                AppEvent::RemoveVolume(name, force) => self.remove_volume(name, force).await,
-                AppEvent::UpdateNetworks => self.update_networks().await,
-                AppEvent::RemoveNetwork(name) => self.remove_network(name).await,
-                AppEvent::UpdateImages => self.update_images().await,
-                AppEvent::RemoveImage(id, force) => self.remove_image(id, force).await,
-                AppEvent::Back => self.container_info = None,
+                AppEvent::UpdateContainers => self.request_containers(),
+                AppEvent::UpdateContainerInfo(id) => self.request_container_details(id),
+                AppEvent::RestartContainer(id) => self.request_restart_container(id),
+                AppEvent::StopContainer(id) => self.request_stop_container(id),
+                AppEvent::KillContainer(id) => self.request_kill_container(id),
+                AppEvent::RemoveContainer(id) => self.request_remove_container(id),
+                AppEvent::GoToContainerDetails(id) => self.request_container_details_open(id),
+                AppEvent::UpdateVolumes => self.request_volumes(),
+                AppEvent::RemoveVolume(name, force) => self.request_remove_volume(name, force),
+                AppEvent::UpdateNetworks => self.request_networks(),
+                AppEvent::RemoveNetwork(name) => self.request_remove_network(name),
+                AppEvent::UpdateImages => self.request_images(),
+                AppEvent::RemoveImage(id, force) => self.request_remove_image(id, force),
+                AppEvent::Back => {
+                    self.details_requested = false;
+                    self.container_info = None;
+                }
             },
         }
         Ok(())
@@ -190,14 +212,6 @@ impl<C: DockerApi> App<C> {
         self.selected_tab = self.selected_tab.previous()
     }
 
-    async fn go_to_container_info(&mut self, container_id: String) {
-        if let Some(data) = self.get_container_data(container_id).await {
-            let mut container_info_block = ContainerInfoBlock::default();
-            container_info_block.update_data(data);
-            self.container_info = Some(Box::new(container_info_block));
-        }
-    }
-
     fn tick(&mut self) -> Result<Option<AppEvent>> {
         if let Some(info) = self.container_info.as_mut() {
             return info.tick();
@@ -237,88 +251,240 @@ impl<C: DockerApi> App<C> {
         }
     }
 
-    async fn get_container_data(&mut self, container_id: String) -> Option<ContainerData> {
-        let result = self.docker_client.inspect_container(&container_id).await;
-        self.ok_or_report(SelectedTab::Containers, result)
-            .map(ContainerData::from)
+    /// Maps a Docker outcome's resource kind back to the tab that owns it.
+    fn tab_of(resource: ResourceKind) -> SelectedTab {
+        match resource {
+            ResourceKind::Containers => SelectedTab::Containers,
+            ResourceKind::Volumes => SelectedTab::Volumes,
+            ResourceKind::Networks => SelectedTab::Networks,
+            ResourceKind::Images => SelectedTab::Images,
+        }
     }
 
-    async fn update_container_details(&mut self, container_id: String) {
-        let Some(data) = self.get_container_data(container_id).await else {
+    fn begin_action(&mut self, tab: SelectedTab) {
+        match tab {
+            SelectedTab::Containers => self.container_table.begin_pending_op(),
+            SelectedTab::Volumes => self.volume_table.begin_pending_op(),
+            SelectedTab::Networks => self.network_table.begin_pending_op(),
+            SelectedTab::Images => self.image_table.begin_pending_op(),
+        }
+    }
+
+    fn end_action(&mut self, tab: SelectedTab) {
+        match tab {
+            SelectedTab::Containers => self.container_table.end_pending_op(),
+            SelectedTab::Volumes => self.volume_table.end_pending_op(),
+            SelectedTab::Networks => self.network_table.end_pending_op(),
+            SelectedTab::Images => self.image_table.end_pending_op(),
+        }
+    }
+
+    /// Runs a Docker operation off the event loop; its outcome comes back as `Event::Docker`.
+    fn spawn_docker<F, Fut>(&self, op: F)
+    where
+        F: FnOnce(C) -> Fut + Send + 'static,
+        Fut: Future<Output = DockerOutcome> + Send + 'static,
+    {
+        let client = self.docker_client.clone();
+        let sender = self.events.sender();
+        tokio::spawn(async move {
+            let _ = sender.send(Event::Docker(op(client).await));
+        });
+    }
+
+    fn request_containers(&mut self) {
+        if self.pending.containers {
             return;
-        };
-        if let Some(info_block) = self.container_info.as_mut() {
-            info_block.update_data(data);
         }
+        self.pending.containers = true;
+        self.spawn_docker(
+            |c| async move { DockerOutcome::ContainersListed(c.list_containers().await) },
+        );
     }
 
-    async fn restart_container(&mut self, container_id: String) {
-        let result = self.docker_client.restart_container(&container_id).await;
-        self.ok_or_report(SelectedTab::Containers, result);
-    }
-
-    async fn stop_container(&mut self, container_id: String) {
-        let result = self.docker_client.stop_container(&container_id).await;
-        self.ok_or_report(SelectedTab::Containers, result);
-    }
-
-    async fn kill_container(&mut self, container_id: String) {
-        let result = self.docker_client.kill_container(&container_id).await;
-        self.ok_or_report(SelectedTab::Containers, result);
-    }
-
-    async fn remove_container(&mut self, container_id: String) {
-        let result = self.docker_client.remove_container(&container_id).await;
-        self.ok_or_report(SelectedTab::Containers, result);
-    }
-
-    async fn update_containers(&mut self) {
-        let result = self.docker_client.list_containers().await;
-        if let Some(result) = self.ok_or_report(SelectedTab::Containers, result) {
-            let containers = ContainerTableRow::from_list(result);
-            self.container_table.update_with_items(containers);
+    fn request_volumes(&mut self) {
+        if self.pending.volumes {
+            return;
         }
+        self.pending.volumes = true;
+        self.spawn_docker(|c| async move { DockerOutcome::VolumesListed(c.list_volumes().await) });
     }
 
-    async fn update_volumes(&mut self) {
-        let result = self.docker_client.list_volumes().await;
-        if let Some(response) = self.ok_or_report(SelectedTab::Volumes, result)
-            && let Some(volumes) = response.volumes
-        {
-            let volumes = VolumeTableRow::from_list(volumes);
-            self.volume_table.update_with_items(volumes);
+    fn request_networks(&mut self) {
+        if self.pending.networks {
+            return;
         }
+        self.pending.networks = true;
+        self.spawn_docker(
+            |c| async move { DockerOutcome::NetworksListed(c.list_networks().await) },
+        );
     }
 
-    async fn update_networks(&mut self) {
-        let result = self.docker_client.list_networks().await;
-        if let Some(result) = self.ok_or_report(SelectedTab::Networks, result) {
-            let networks = NetworkTableRow::from_list(result);
-            self.network_table.update_with_items(networks);
+    fn request_images(&mut self) {
+        if self.pending.images {
+            return;
         }
+        self.pending.images = true;
+        self.spawn_docker(|c| async move { DockerOutcome::ImagesListed(c.list_images().await) });
     }
 
-    async fn update_images(&mut self) {
-        let result = self.docker_client.list_images().await;
-        if let Some(result) = self.ok_or_report(SelectedTab::Images, result) {
-            let images = ImageTableRow::from_list(result);
-            self.image_table.update_with_items(images);
+    fn request_container_details(&mut self, id: String) {
+        if self.pending.container_info {
+            return;
         }
+        self.pending.container_info = true;
+        self.spawn_docker(|c| async move {
+            let result = c.inspect_container(&id).await.map(Box::new);
+            DockerOutcome::ContainerInspected {
+                open_details: false,
+                result,
+            }
+        });
     }
 
-    async fn remove_volume(&mut self, name: String, force: bool) {
-        let result = self.docker_client.remove_volume(&name, force).await;
-        self.ok_or_report(SelectedTab::Volumes, result);
+    fn request_container_details_open(&mut self, id: String) {
+        self.details_requested = true;
+        self.spawn_docker(|c| async move {
+            let result = c.inspect_container(&id).await.map(Box::new);
+            DockerOutcome::ContainerInspected {
+                open_details: true,
+                result,
+            }
+        });
     }
 
-    async fn remove_network(&mut self, name: String) {
-        let result = self.docker_client.remove_network(&name).await;
-        self.ok_or_report(SelectedTab::Networks, result);
+    fn request_restart_container(&mut self, id: String) {
+        self.begin_action(SelectedTab::Containers);
+        self.spawn_docker(|c| async move {
+            DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Containers,
+                result: c.restart_container(&id).await,
+            }
+        });
     }
 
-    async fn remove_image(&mut self, id: String, force: bool) {
-        let result = self.docker_client.remove_image(&id, force).await;
-        self.ok_or_report(SelectedTab::Images, result);
+    fn request_stop_container(&mut self, id: String) {
+        self.begin_action(SelectedTab::Containers);
+        self.spawn_docker(|c| async move {
+            DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Containers,
+                result: c.stop_container(&id).await,
+            }
+        });
+    }
+
+    fn request_kill_container(&mut self, id: String) {
+        self.begin_action(SelectedTab::Containers);
+        self.spawn_docker(|c| async move {
+            DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Containers,
+                result: c.kill_container(&id).await,
+            }
+        });
+    }
+
+    fn request_remove_container(&mut self, id: String) {
+        self.begin_action(SelectedTab::Containers);
+        self.spawn_docker(|c| async move {
+            DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Containers,
+                result: c.remove_container(&id).await,
+            }
+        });
+    }
+
+    fn request_remove_volume(&mut self, name: String, force: bool) {
+        self.begin_action(SelectedTab::Volumes);
+        self.spawn_docker(move |c| async move {
+            DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Volumes,
+                result: c.remove_volume(&name, force).await,
+            }
+        });
+    }
+
+    fn request_remove_network(&mut self, name: String) {
+        self.begin_action(SelectedTab::Networks);
+        self.spawn_docker(|c| async move {
+            DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Networks,
+                result: c.remove_network(&name).await,
+            }
+        });
+    }
+
+    fn request_remove_image(&mut self, id: String, force: bool) {
+        self.begin_action(SelectedTab::Images);
+        self.spawn_docker(move |c| async move {
+            DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Images,
+                result: c.remove_image(&id, force).await,
+            }
+        });
+    }
+
+    fn apply_docker_outcome(&mut self, outcome: DockerOutcome) {
+        match outcome {
+            DockerOutcome::ContainersListed(result) => {
+                self.pending.containers = false;
+                if let Some(list) = self.ok_or_report(SelectedTab::Containers, result) {
+                    self.container_table
+                        .update_with_items(ContainerTableRow::from_list(list));
+                }
+            }
+            DockerOutcome::VolumesListed(result) => {
+                self.pending.volumes = false;
+                if let Some(response) = self.ok_or_report(SelectedTab::Volumes, result)
+                    && let Some(volumes) = response.volumes
+                {
+                    self.volume_table
+                        .update_with_items(VolumeTableRow::from_list(volumes));
+                }
+            }
+            DockerOutcome::NetworksListed(result) => {
+                self.pending.networks = false;
+                if let Some(list) = self.ok_or_report(SelectedTab::Networks, result) {
+                    self.network_table
+                        .update_with_items(NetworkTableRow::from_list(list));
+                }
+            }
+            DockerOutcome::ImagesListed(result) => {
+                self.pending.images = false;
+                if let Some(list) = self.ok_or_report(SelectedTab::Images, result) {
+                    self.image_table
+                        .update_with_items(ImageTableRow::from_list(list));
+                }
+            }
+            DockerOutcome::ContainerInspected {
+                open_details,
+                result,
+            } => {
+                if !open_details {
+                    self.pending.container_info = false;
+                }
+                let Some(data) = self
+                    .ok_or_report(SelectedTab::Containers, result)
+                    .map(|r| ContainerData::from(*r))
+                else {
+                    return;
+                };
+                if open_details {
+                    if !self.details_requested {
+                        return;
+                    }
+                    let mut container_info_block = ContainerInfoBlock::default();
+                    container_info_block.update_data(data);
+                    self.container_info = Some(Box::new(container_info_block));
+                } else if let Some(block) = self.container_info.as_mut() {
+                    block.update_data(data);
+                }
+            }
+            DockerOutcome::ActionCompleted { resource, result } => {
+                let tab = Self::tab_of(resource);
+                self.end_action(tab);
+                self.ok_or_report(tab, result);
+            }
+        }
     }
 }
 
@@ -372,9 +538,9 @@ mod tests {
         VolumeListResponse,
     };
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
 
-    #[derive(Default)]
+    #[derive(Clone, Default)]
     struct MockDockerClient {
         containers: Vec<ContainerSummary>,
         volumes: Vec<Volume>,
@@ -382,7 +548,7 @@ mod tests {
         images: Vec<ImageSummary>,
         inspect: Option<ContainerInspectResponse>,
         fail_with: Option<DockerError>,
-        calls: Mutex<Vec<String>>,
+        calls: Arc<Mutex<Vec<String>>>,
     }
 
     impl MockDockerClient {
@@ -530,185 +696,180 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn update_containers_populates_table() {
-        let mock = MockDockerClient {
-            containers: vec![container_summary("a"), container_summary("b")],
-            ..Default::default()
-        };
+    #[test]
+    fn update_containers_populates_table() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.update_containers().await;
+        app.apply_docker_outcome(DockerOutcome::ContainersListed(Ok(vec![
+            container_summary("a"),
+            container_summary("b"),
+        ])));
 
         assert_eq!(app.container_table.table_info().items.len(), 2);
     }
 
-    #[tokio::test]
-    async fn update_volumes_populates_table() {
-        let mock = MockDockerClient {
-            volumes: vec![volume("a"), volume("b")],
-            ..Default::default()
-        };
+    #[test]
+    fn update_volumes_populates_table() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.update_volumes().await;
+        app.apply_docker_outcome(DockerOutcome::VolumesListed(Ok(VolumeListResponse {
+            volumes: Some(vec![volume("a"), volume("b")]),
+            ..Default::default()
+        })));
 
         assert_eq!(app.volume_table.table_info().items.len(), 2);
     }
 
-    #[tokio::test]
-    async fn update_networks_populates_table() {
-        let mock = MockDockerClient {
-            networks: vec![network("111111111111", "a"), network("222222222222", "b")],
-            ..Default::default()
-        };
+    #[test]
+    fn update_networks_populates_table() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.update_networks().await;
+        app.apply_docker_outcome(DockerOutcome::NetworksListed(Ok(vec![
+            network("111111111111", "a"),
+            network("222222222222", "b"),
+        ])));
 
         assert_eq!(app.network_table.table_info().items.len(), 2);
     }
 
-    #[tokio::test]
-    async fn update_images_populates_table() {
-        let mock = MockDockerClient {
-            images: vec![
-                image("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"),
-                image("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abce"),
-            ],
-            ..Default::default()
-        };
+    #[test]
+    fn update_images_populates_table() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.update_images().await;
+        app.apply_docker_outcome(DockerOutcome::ImagesListed(Ok(vec![
+            image("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"),
+            image("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abce"),
+        ])));
 
         assert_eq!(app.image_table.table_info().items.len(), 2);
     }
 
-    #[tokio::test]
-    async fn restart_container_error_is_shown_in_footer() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::Conflict {
-                message: "daemon says no".to_string(),
-            }),
-            ..Default::default()
-        };
+    #[test]
+    fn restart_container_error_is_shown_in_footer() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.restart_container("container-id".to_string()).await;
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Containers,
+            result: Err(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+        });
 
         let err = app.container_table.table_info().err.clone().unwrap();
         assert_eq!(err, "[ERR] Conflict: daemon says no");
     }
 
-    #[tokio::test]
-    async fn stop_container_error_is_shown_in_footer() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::Conflict {
-                message: "daemon says no".to_string(),
-            }),
-            ..Default::default()
-        };
+    #[test]
+    fn stop_container_error_is_shown_in_footer() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.stop_container("container-id".to_string()).await;
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Containers,
+            result: Err(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+        });
 
         let err = app.container_table.table_info().err.clone().unwrap();
         assert_eq!(err, "[ERR] Conflict: daemon says no");
     }
 
-    #[tokio::test]
-    async fn kill_container_error_is_shown_in_footer() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::Conflict {
-                message: "daemon says no".to_string(),
-            }),
-            ..Default::default()
-        };
+    #[test]
+    fn kill_container_error_is_shown_in_footer() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.kill_container("container-id".to_string()).await;
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Containers,
+            result: Err(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+        });
 
         let err = app.container_table.table_info().err.clone().unwrap();
         assert_eq!(err, "[ERR] Conflict: daemon says no");
     }
 
-    #[tokio::test]
-    async fn remove_volume_error_is_shown_in_footer() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::Conflict {
+    #[test]
+    fn remove_volume_error_is_shown_in_footer() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Volumes,
+            result: Err(DockerError::Conflict {
                 message: "volume is in use".to_string(),
             }),
-            ..Default::default()
-        };
-        let mut app = App::with_client(mock);
-
-        app.remove_volume("volume-name".to_string(), false).await;
+        });
 
         let err = app.volume_table.table_info().err.clone().unwrap();
         assert_eq!(err, "[ERR] Conflict: volume is in use");
     }
 
-    #[tokio::test]
-    async fn remove_network_error_is_shown_in_footer() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::Conflict {
-                message: "daemon says no".to_string(),
-            }),
-            ..Default::default()
-        };
+    #[test]
+    fn remove_network_error_is_shown_in_footer() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.remove_network("network-name".to_string()).await;
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Networks,
+            result: Err(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+        });
 
         let err = app.network_table.table_info().err.clone().unwrap();
         assert_eq!(err, "[ERR] Conflict: daemon says no");
     }
 
-    #[tokio::test]
-    async fn remove_image_error_is_shown_in_footer() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::Conflict {
-                message: "daemon says no".to_string(),
-            }),
-            ..Default::default()
-        };
+    #[test]
+    fn remove_image_error_is_shown_in_footer() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.remove_image("image-id".to_string(), false).await;
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Images,
+            result: Err(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+        });
 
         let err = app.image_table.table_info().err.clone().unwrap();
         assert_eq!(err, "[ERR] Conflict: daemon says no");
     }
 
-    #[tokio::test]
-    async fn list_failure_shows_error_on_owning_tab() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::DaemonUnreachable {
-                details: "connection refused".to_string(),
-            }),
-            ..Default::default()
-        };
+    #[test]
+    fn list_failure_shows_error_on_owning_tab() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
         assert_eq!(app.selected_tab as usize, SelectedTab::Containers as usize);
 
-        app.update_images().await;
+        app.apply_docker_outcome(DockerOutcome::ImagesListed(Err(
+            DockerError::DaemonUnreachable {
+                details: "connection refused".to_string(),
+            },
+        )));
 
         assert!(app.image_table.table_info().err.is_some());
         assert!(app.container_table.table_info().err.is_none());
     }
 
-    #[tokio::test]
-    async fn list_failure_keeps_previous_items() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::DaemonUnreachable {
-                details: "connection refused".to_string(),
-            }),
-            ..Default::default()
-        };
+    #[test]
+    fn list_failure_keeps_previous_items() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.update_containers().await;
+        app.apply_docker_outcome(DockerOutcome::ContainersListed(Err(
+            DockerError::DaemonUnreachable {
+                details: "connection refused".to_string(),
+            },
+        )));
 
         assert_eq!(app.container_table.table_info().items.len(), 0);
         assert!(app.container_table.table_info().err.is_some());
@@ -716,16 +877,17 @@ mod tests {
 
     #[tokio::test]
     async fn go_to_container_info_opens_and_back_closes() {
-        let mock = MockDockerClient {
-            inspect: Some(ContainerInspectResponse {
-                id: Some("container-id".to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.go_to_container_info("container-id".to_string()).await;
+        app.request_container_details_open("container-id".to_string());
+        app.apply_docker_outcome(DockerOutcome::ContainerInspected {
+            open_details: true,
+            result: Ok(Box::new(ContainerInspectResponse {
+                id: Some("container-id".to_string()),
+                ..Default::default()
+            })),
+        });
         assert!(app.container_info.is_some());
 
         let event = app.handle_key_event(KeyEvent::from(KeyCode::Esc)).unwrap();
@@ -734,21 +896,137 @@ mod tests {
 
     #[tokio::test]
     async fn key_events_route_to_info_block_when_open() {
-        let mock = MockDockerClient {
-            inspect: Some(ContainerInspectResponse {
-                id: Some("container-id".to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.go_to_container_info("container-id".to_string()).await;
+        app.request_container_details_open("container-id".to_string());
+        app.apply_docker_outcome(DockerOutcome::ContainerInspected {
+            open_details: true,
+            result: Ok(Box::new(ContainerInspectResponse {
+                id: Some("container-id".to_string()),
+                ..Default::default()
+            })),
+        });
 
         let tab_before = app.selected_tab as usize;
         app.handle_key_event(KeyEvent::from(KeyCode::Char('t')))
             .unwrap();
         assert_eq!(app.selected_tab as usize, tab_before);
+    }
+
+    #[tokio::test]
+    async fn request_containers_dispatches_to_the_client() {
+        let mock = MockDockerClient::default();
+        let calls = mock.calls.clone();
+        let mut app = App::with_client(mock);
+
+        app.request_containers();
+
+        let event = app.events.next().await.unwrap();
+        assert!(matches!(
+            event,
+            Event::Docker(DockerOutcome::ContainersListed(Ok(_)))
+        ));
+        assert_eq!(*calls.lock().unwrap(), vec!["list_containers".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn duplicate_refresh_is_dropped_while_one_is_in_flight() {
+        let mock = MockDockerClient::default();
+        let calls = mock.calls.clone();
+        let mut app = App::with_client(mock);
+
+        app.request_containers();
+        app.request_containers();
+
+        let _ = app.events.next().await.unwrap();
+        assert!(app.events.try_next().is_none());
+        assert_eq!(calls.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn refresh_is_allowed_again_after_the_outcome_is_applied() {
+        let mock = MockDockerClient::default();
+        let calls = mock.calls.clone();
+        let mut app = App::with_client(mock);
+
+        app.request_containers();
+        let event = app.events.next().await.unwrap();
+        if let Event::Docker(outcome) = event {
+            app.apply_docker_outcome(outcome);
+        }
+
+        app.request_containers();
+        let _ = app.events.next().await.unwrap();
+
+        assert_eq!(calls.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn actions_are_not_deduplicated() {
+        let mock = MockDockerClient::default();
+        let calls = mock.calls.clone();
+        let mut app = App::with_client(mock);
+
+        app.request_stop_container("container-a".to_string());
+        app.request_stop_container("container-b".to_string());
+
+        let _ = app.events.next().await.unwrap();
+        let _ = app.events.next().await.unwrap();
+
+        assert_eq!(calls.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn action_marks_and_clears_the_pending_indicator() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        app.request_stop_container("container-id".to_string());
+        assert_eq!(app.container_table.table_info().pending_ops, 1);
+
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Containers,
+            result: Ok(()),
+        });
+        assert_eq!(app.container_table.table_info().pending_ops, 0);
+    }
+
+    #[tokio::test]
+    async fn back_prevents_a_late_details_open() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        app.request_container_details_open("container-id".to_string());
+        app.details_requested = false;
+        app.container_info = None;
+
+        app.apply_docker_outcome(DockerOutcome::ContainerInspected {
+            open_details: true,
+            result: Ok(Box::new(ContainerInspectResponse {
+                id: Some("container-id".to_string()),
+                ..Default::default()
+            })),
+        });
+
+        assert!(app.container_info.is_none());
+    }
+
+    #[tokio::test]
+    async fn stop_container_failure_reaches_the_footer_through_the_channel() {
+        let mock = MockDockerClient {
+            fail_with: Some(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.request_stop_container("container-id".to_string());
+        app.process_next_event().await.unwrap();
+
+        let err = app.container_table.table_info().err.clone().unwrap();
+        assert_eq!(err, "[ERR] Conflict: daemon says no");
     }
 
     #[test]

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -9,6 +9,7 @@ use bollard::network::ListNetworksOptions;
 use bollard::secret::{ContainerInspectResponse, ImageSummary, Network, VolumeListResponse};
 use bollard::volume::{ListVolumesOptions, RemoveVolumeOptions};
 use color_eyre::eyre::Result;
+use std::future::Future;
 
 use crate::docker::error::DockerResult;
 
@@ -25,23 +26,32 @@ impl DockerClient {
     }
 }
 
-/// Crate-internal trait, App is awaited directly by #[tokio::main] and never
-/// tokio::spawn-ed, so no Send bound is required.
-#[allow(async_fn_in_trait)]
-pub trait DockerApi {
-    async fn list_containers(&self) -> DockerResult<Vec<ContainerSummary>>;
-    async fn stop_container(&self, container_id: &str) -> DockerResult<()>;
-    async fn restart_container(&self, container_id: &str) -> DockerResult<()>;
-    async fn kill_container(&self, container_id: &str) -> DockerResult<()>;
-    async fn remove_container(&self, container_id: &str) -> DockerResult<()>;
-    async fn inspect_container(&self, container_id: &str)
-    -> DockerResult<ContainerInspectResponse>;
-    async fn list_volumes(&self) -> DockerResult<VolumeListResponse>;
-    async fn remove_volume(&self, name: &str, force: bool) -> DockerResult<()>;
-    async fn list_networks(&self) -> DockerResult<Vec<Network>>;
-    async fn remove_network(&self, name: &str) -> DockerResult<()>;
-    async fn list_images(&self) -> DockerResult<Vec<ImageSummary>>;
-    async fn remove_image(&self, id: &str, force: bool) -> DockerResult<()>;
+/// Crate-internal Docker surface. Methods return `Send` futures because `App`
+/// spawns them as background tasks (see `App::spawn_docker`).
+pub trait DockerApi: Clone + Send + Sync + 'static {
+    fn list_containers(&self) -> impl Future<Output = DockerResult<Vec<ContainerSummary>>> + Send;
+    fn stop_container(&self, container_id: &str) -> impl Future<Output = DockerResult<()>> + Send;
+    fn restart_container(
+        &self,
+        container_id: &str,
+    ) -> impl Future<Output = DockerResult<()>> + Send;
+    fn kill_container(&self, container_id: &str) -> impl Future<Output = DockerResult<()>> + Send;
+    fn remove_container(&self, container_id: &str)
+    -> impl Future<Output = DockerResult<()>> + Send;
+    fn inspect_container(
+        &self,
+        container_id: &str,
+    ) -> impl Future<Output = DockerResult<ContainerInspectResponse>> + Send;
+    fn list_volumes(&self) -> impl Future<Output = DockerResult<VolumeListResponse>> + Send;
+    fn remove_volume(
+        &self,
+        name: &str,
+        force: bool,
+    ) -> impl Future<Output = DockerResult<()>> + Send;
+    fn list_networks(&self) -> impl Future<Output = DockerResult<Vec<Network>>> + Send;
+    fn remove_network(&self, name: &str) -> impl Future<Output = DockerResult<()>> + Send;
+    fn list_images(&self) -> impl Future<Output = DockerResult<Vec<ImageSummary>>> + Send;
+    fn remove_image(&self, id: &str, force: bool) -> impl Future<Output = DockerResult<()>> + Send;
 }
 
 impl DockerApi for DockerClient {

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,9 +1,14 @@
+use bollard::secret::{
+    ContainerInspectResponse, ContainerSummary, ImageSummary, Network, VolumeListResponse,
+};
 use color_eyre::eyre::{OptionExt, Result};
 use crossterm::event::KeyEventKind;
 use futures::{FutureExt, StreamExt};
 use ratatui::crossterm::event::{Event::Key, KeyEvent};
 use std::time::Duration;
 use tokio::sync::mpsc;
+
+use crate::docker::error::DockerResult;
 
 const TICK_FPS: f64 = 30.0;
 
@@ -12,6 +17,7 @@ pub enum Event {
     Tick,
     Crossterm(KeyEvent),
     App(AppEvent),
+    Docker(DockerOutcome),
 }
 
 #[derive(Clone, Debug)]
@@ -31,6 +37,32 @@ pub enum AppEvent {
     UpdateImages,
     RemoveImage(String, bool),
     Back,
+}
+
+/// Outcome of a background Docker operation, delivered back through the event channel
+/// once the spawned task that ran it completes.
+#[derive(Clone, Debug)]
+pub enum DockerOutcome {
+    ContainersListed(DockerResult<Vec<ContainerSummary>>),
+    VolumesListed(DockerResult<VolumeListResponse>),
+    NetworksListed(DockerResult<Vec<Network>>),
+    ImagesListed(DockerResult<Vec<ImageSummary>>),
+    ContainerInspected {
+        open_details: bool,
+        result: DockerResult<Box<ContainerInspectResponse>>,
+    },
+    ActionCompleted {
+        resource: ResourceKind,
+        result: DockerResult<()>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResourceKind {
+    Containers,
+    Volumes,
+    Networks,
+    Images,
 }
 
 #[derive(Debug)]
@@ -58,12 +90,22 @@ impl EventHandler {
         let _ = self.sender.send(Event::App(app_event));
     }
 
+    /// Clone of the event channel sender, for background tasks that report Docker results.
+    pub fn sender(&self) -> mpsc::UnboundedSender<Event> {
+        self.sender.clone()
+    }
+
     /// Test-only constructor; skips the crossterm reader task so `App` can be driven
     /// deterministically without a terminal.
     #[cfg(test)]
     pub fn new_without_reader() -> Self {
         let (sender, receiver) = mpsc::unbounded_channel();
         Self { sender, receiver }
+    }
+
+    #[cfg(test)]
+    pub fn try_next(&mut self) -> Option<Event> {
+        self.receiver.try_recv().ok()
     }
 }
 
@@ -117,5 +159,27 @@ mod tests {
 
         let event = handler.next().await.unwrap();
         assert!(matches!(event, Event::App(AppEvent::Quit)));
+    }
+
+    #[tokio::test]
+    async fn docker_outcome_is_delivered_through_the_sender_clone() {
+        let mut handler = EventHandler::new_without_reader();
+        let sender = handler.sender();
+
+        sender
+            .send(Event::Docker(DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Containers,
+                result: Ok(()),
+            }))
+            .unwrap();
+
+        let event = handler.next().await.unwrap();
+        assert!(matches!(
+            event,
+            Event::Docker(DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Containers,
+                result: Ok(())
+            })
+        ));
     }
 }

--- a/src/ui/resource_table.rs
+++ b/src/ui/resource_table.rs
@@ -23,6 +23,7 @@ pub struct ResourceTableInfo<RowType> {
     pub style: TableStyle,
     pub err: Option<String>,
     pub ticker: RefreshTicker,
+    pub pending_ops: usize,
     scrollbar_state: ScrollbarState,
     scroll: usize,
 }
@@ -36,6 +37,7 @@ impl<RowType> Default for ResourceTableInfo<RowType> {
             style: TableStyle::default(),
             err: None,
             ticker: RefreshTicker::default(),
+            pending_ops: 0,
             scrollbar_state: ScrollbarState::default(),
             scroll: 0,
         }
@@ -236,6 +238,10 @@ pub trait ResourceTable {
         let mut text = self.footer_text();
         let mut border = None;
 
+        if self.table_info().pending_ops > 0 {
+            text = format!(" [working]{text}");
+        }
+
         if let Some(err) = &self.table_info().err {
             border = Some(Style::new().red());
             text = err.clone();
@@ -289,6 +295,15 @@ pub trait ResourceTable {
 
     fn show_err(&mut self, err: &DockerError) {
         self.table_info_mut().err = Some(format!("[ERR] {err}"));
+    }
+
+    fn begin_pending_op(&mut self) {
+        self.table_info_mut().pending_ops += 1;
+    }
+
+    fn end_pending_op(&mut self) {
+        let info = self.table_info_mut();
+        info.pending_ops = info.pending_ops.saturating_sub(1);
     }
 }
 
@@ -483,6 +498,34 @@ mod tests {
         table.update_with_items(rows(&[("a", true), ("b", true)]));
         // Items were already non-empty before this update, so selection stays untouched.
         assert_eq!(table.info.state.selected(), None);
+    }
+
+    #[test]
+    fn footer_shows_working_prefix_while_an_op_is_pending() {
+        let mut table = TestTable::default();
+        table.begin_pending_op();
+
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| table.draw(f, f.area()).unwrap()).unwrap();
+
+        let buffer: &Buffer = terminal.backend().buffer();
+        let content: String = buffer.content.iter().map(|c| c.symbol()).collect();
+        assert!(content.contains("[working]"));
+
+        table.info.err = Some("boom".to_string());
+        terminal.draw(|f| table.draw(f, f.area()).unwrap()).unwrap();
+        let buffer: &Buffer = terminal.backend().buffer();
+        let content: String = buffer.content.iter().map(|c| c.symbol()).collect();
+        assert!(content.contains("boom"));
+        assert!(!content.contains("[working]"));
+    }
+
+    #[test]
+    fn end_pending_op_saturates_at_zero() {
+        let mut table = TestTable::default();
+        table.end_pending_op();
+        assert_eq!(table.info.pending_ops, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the UI freeze described in #21: all Docker API calls were awaited inline in `App::process_next_event`, so a slow stop/restart/remove (e.g. a container ignoring SIGTERM for the 10s default timeout) blocked drawing and input entirely.

- **Background tasks:** every Docker call is now spawned via a small `App::spawn_docker` helper over a cloned client; the result comes back through the existing event channel as a new top-level `Event::Docker(DockerOutcome)` and is applied by a synchronous `apply_docker_outcome` handler on the main loop. The intent vocabulary (`AppEvent`) is untouched.
- **Trait bounds:** `DockerApi` methods now return `impl Future<...> + Send` and the trait requires `Clone + Send + Sync + 'static`, so operations can be spawned; `DockerClient` bodies are unchanged (bollard's `Docker` clones cheaply).
- **In-flight guard:** list refreshes are deduplicated to one outstanding request per resource kind (`PendingRefreshes`), so ~2.5/s tick-driven refreshes can't pile up against a slow/hanging daemon. This also makes out-of-order list results impossible. Actions (stop/kill/restart/remove) are keypress-driven and intentionally not guarded.
- **Late-result safety:** a `details_requested` flag prevents an in-flight inspect from reopening the container details view after the user pressed Esc.
- **Pending indicator:** tables show a `[working]` footer prefix while an action is in flight (per-row indicators deferred as a follow-up); error display keeps precedence, so the #19 error UX is unchanged.

## Test plan

- Apply-side tests converted to synchronous `apply_docker_outcome` calls (table population, footer errors, owning-tab routing).
- New spawn-side tests: dispatch through the channel, duplicate-refresh dropping, refresh re-allowed after completion, actions not deduplicated, pending indicator lifecycle, late details-open prevention, and one end-to-end failure-to-footer test.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo build`, `cargo test` (90 passed) all clean.
- Manual: with a SIGTERM-ignoring container, `s` keeps the UI fully responsive for the whole ~10s; tab/row navigation works during the operation; `[working]` shows and clears.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)