### PR TITLE
fix: stable row order for tied sort keys

### DIFF
--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -168,7 +168,13 @@ impl ResourceRow for ContainerTableRow {
             match (p_is_running, n_is_running) {
                 (true, false) => std::cmp::Ordering::Less,
                 (false, true) => std::cmp::Ordering::Greater,
-                _ => p.state.as_ref().cmp(n.state.as_ref()),
+                // Tie-break equal states by name so row order does not depend
+                // on the order the daemon returned the containers in.
+                _ => p
+                    .state
+                    .as_ref()
+                    .cmp(n.state.as_ref())
+                    .then_with(|| p.name.cmp(&n.name)),
             }
         });
     }
@@ -235,6 +241,27 @@ mod tests {
                 ContainerStateStatusEnum::RESTARTING,
             ]
         );
+    }
+
+    #[test]
+    fn from_list_breaks_equal_state_ties_by_name() {
+        let named = |name: &str| ContainerSummary {
+            id: Some(format!("id-{name}")),
+            names: Some(vec![format!("/{name}")]),
+            state: Some("exited".to_string()),
+            ..Default::default()
+        };
+
+        let names_of = |rows: &[ContainerTableRow]| -> Vec<String> {
+            rows.iter().map(|r| r.name.clone()).collect()
+        };
+
+        // Both input orders must yield the same on-screen order.
+        let one_way = ContainerTableRow::from_list(vec![named("bravo"), named("alpha")]);
+        let other_way = ContainerTableRow::from_list(vec![named("alpha"), named("bravo")]);
+
+        assert_eq!(names_of(&one_way), names_of(&other_way));
+        assert_eq!(names_of(&one_way), vec!["alpha", "bravo"]);
     }
 
     #[test]

--- a/src/ui/image_table.rs
+++ b/src/ui/image_table.rs
@@ -102,8 +102,15 @@ impl ResourceRow for ImageTableRow {
     }
 
     fn sort_rows(rows: &mut Vec<Self>) {
-        rows.sort_by_key(|r| r.created_epoch);
-        rows.reverse();
+        // `created` has second resolution, so multi-tag builds of the same
+        // project tie on it; break ties deterministically so rows do not
+        // follow the daemon's unstable tie order and swap on every refresh.
+        rows.sort_by(|a, b| {
+            b.created_epoch
+                .cmp(&a.created_epoch)
+                .then_with(|| a.tags.cmp(&b.tags))
+                .then_with(|| a.id.cmp(&b.id))
+        });
     }
 }
 
@@ -126,6 +133,40 @@ mod tests {
         let ids: Vec<String> = rows.iter().map(|r| r.id.clone()).collect();
 
         assert_eq!(ids, vec!["b", "c", "a"]);
+    }
+
+    #[test]
+    fn from_list_orders_identical_creation_times_deterministically() {
+        let mut dev = image("aaa", 100);
+        dev.repo_tags = vec!["devmon-agent:dev".to_string()];
+        let mut local = image("bbb", 100);
+        local.repo_tags = vec!["devmon-agent:local".to_string()];
+
+        // The daemon's tie order is unstable; both input orders must yield
+        // the same on-screen order.
+        let tags_of = |rows: &[ImageTableRow]| -> Vec<String> {
+            rows.iter().map(|r| r.tags.clone()).collect()
+        };
+
+        let one_way = ImageTableRow::from_list(vec![dev.clone(), local.clone()]);
+        let other_way = ImageTableRow::from_list(vec![local, dev]);
+
+        assert_eq!(tags_of(&one_way), tags_of(&other_way));
+        assert_eq!(
+            tags_of(&one_way),
+            vec!["devmon-agent:dev", "devmon-agent:local"]
+        );
+    }
+
+    #[test]
+    fn from_list_breaks_full_ties_by_id() {
+        let untagged_b = image("bbb", 100);
+        let untagged_a = image("aaa", 100);
+
+        let rows = ImageTableRow::from_list(vec![untagged_b, untagged_a]);
+        let ids: Vec<String> = rows.iter().map(|r| r.id.clone()).collect();
+
+        assert_eq!(ids, vec!["aaa", "bbb"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #35: on the Images tab, images built within the same second (typical for multi-tag builds) kept swapping places on every refresh, because `ImageTableRow::sort_rows` sorted only by the second-resolution `created_epoch` and tied rows fell back to the daemon's unstable tie order.

- Images now sort by creation time descending with **tags, then id** as deterministic tie-breakers. The `reverse()` call (which also flipped the daemon's tie order as a side effect) is gone.
- Containers had the same latent problem: rows with equal states kept daemon order. They now tie-break by **name**.
- Volumes and networks already sort by their unique names — no change needed.

## Test plan

- New `from_list_orders_identical_creation_times_deterministically` and `from_list_breaks_full_ties_by_id` tests (images): both input orders of tied rows must yield the same on-screen order.
- New `from_list_breaks_equal_state_ties_by_name` test (containers), same both-input-orders assertion.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (93 passed) all clean.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)