### PR TITLE
docs: issue labeling and PR linking rules

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -38,6 +38,14 @@ Rules:
 
 Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`
 
+## Issue Workflow
+
+When creating issues:
+
+- Always add the appropriate label(s) at creation time (`gh issue create --label ...`).
+  Available labels include `bug`, `enhancement`, `documentation`, `question`,
+  `good first issue`, `help wanted`; check `gh label list` when unsure.
+
 ## Pull Request Workflow
 
 When creating PRs:
@@ -48,3 +56,7 @@ When creating PRs:
 4. Include a test plan
 5. Push with `-u` on the first push of a new branch
 6. A PR that closes an issue carries a bare `Closes #N` line in its body
+7. Always link the PR to its related issue (`Closes #N` for fixes, `Refs #N`
+   for partial work) and add the matching label(s) to the PR as well
+   (`gh pr create --label ...` / `gh pr edit --add-label ...`), mirroring the
+   issue's labels (e.g. `bug` for a fix, `enhancement` for a feature)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,15 @@ keep the history clean and reviews cheap.
 ## Before you write code
 
 For anything more than a small fix, open an issue first so the change can be
-discussed before you invest time in it.
+discussed before you invest time in it. Label the issue when you open it
+(`bug`, `enhancement`, `documentation`, ...).
+
+## Pull requests
+
+- Link the PR to its issue: a bare `Closes #N` line in the body for a PR that
+  finishes the issue, `Refs #N` for partial work.
+- Mirror the issue's labels on the PR (e.g. `bug` for a fix, `enhancement`
+  for a feature).
 
 ## Language
 


### PR DESCRIPTION
## Summary

Documents two workflow rules requested by the maintainer, in both the internal workflow rules (`.claude/rules/git-workflow.md`) and the contributor-facing `CONTRIBUTING.md`:

- Every new issue gets the appropriate label(s) at creation time.
- Every PR is linked to its related issue (bare `Closes #N` for fixes, `Refs #N` for partial work) and mirrors the issue's labels.

## Test plan

Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)