### PR TITLE
perf: redraw only on state change and cache container detail lines

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -35,6 +35,7 @@ pub struct App<C: DockerApi> {
     image_table: ImageTable,
     pending: PendingRefreshes,
     details_requested: bool,
+    dirty: bool,
 }
 
 /// Tracks in-flight list requests so `App` never has more than one outstanding
@@ -62,6 +63,7 @@ impl App<DockerClient> {
             image_table: ImageTable::default(),
             pending: PendingRefreshes::default(),
             details_requested: false,
+            dirty: true,
         })
     }
 }
@@ -84,6 +86,7 @@ impl<C: DockerApi> App<C> {
             image_table: ImageTable::default(),
             pending: PendingRefreshes::default(),
             details_requested: false,
+            dirty: true,
         }
     }
 
@@ -91,7 +94,10 @@ impl<C: DockerApi> App<C> {
         self.request_containers();
 
         while self.running {
-            terminal.draw(|frame| self.draw(frame, frame.area()))?;
+            if self.dirty {
+                terminal.draw(|frame| self.draw(frame, frame.area()))?;
+                self.dirty = false;
+            }
             self.process_next_event().await?;
         }
         Ok(())
@@ -146,31 +152,51 @@ impl<C: DockerApi> App<C> {
                 }
             }
             Event::Crossterm(key_event) => {
+                self.dirty = true;
                 if let Some(event) = self.handle_key_event(key_event)? {
                     self.events.send(event);
                 }
             }
+            Event::Resize => {
+                self.dirty = true;
+            }
             Event::Docker(outcome) => self.apply_docker_outcome(outcome),
-            Event::App(app_event) => match app_event {
-                AppEvent::Quit => self.quit(),
-                AppEvent::UpdateContainers => self.request_containers(),
-                AppEvent::UpdateContainerInfo(id) => self.request_container_details(id),
-                AppEvent::RestartContainer(id) => self.request_restart_container(id),
-                AppEvent::StopContainer(id) => self.request_stop_container(id),
-                AppEvent::KillContainer(id) => self.request_kill_container(id),
-                AppEvent::RemoveContainer(id) => self.request_remove_container(id),
-                AppEvent::GoToContainerDetails(id) => self.request_container_details_open(id),
-                AppEvent::UpdateVolumes => self.request_volumes(),
-                AppEvent::RemoveVolume(name, force) => self.request_remove_volume(name, force),
-                AppEvent::UpdateNetworks => self.request_networks(),
-                AppEvent::RemoveNetwork(name) => self.request_remove_network(name),
-                AppEvent::UpdateImages => self.request_images(),
-                AppEvent::RemoveImage(id, force) => self.request_remove_image(id, force),
-                AppEvent::Back => {
-                    self.details_requested = false;
-                    self.container_info = None;
+            Event::App(app_event) => {
+                if matches!(
+                    app_event,
+                    AppEvent::Back
+                        | AppEvent::RestartContainer(_)
+                        | AppEvent::StopContainer(_)
+                        | AppEvent::KillContainer(_)
+                        | AppEvent::RemoveContainer(_)
+                        | AppEvent::RemoveVolume(..)
+                        | AppEvent::RemoveNetwork(_)
+                        | AppEvent::RemoveImage(..)
+                ) {
+                    self.dirty = true;
                 }
-            },
+
+                match app_event {
+                    AppEvent::Quit => self.quit(),
+                    AppEvent::UpdateContainers => self.request_containers(),
+                    AppEvent::UpdateContainerInfo(id) => self.request_container_details(id),
+                    AppEvent::RestartContainer(id) => self.request_restart_container(id),
+                    AppEvent::StopContainer(id) => self.request_stop_container(id),
+                    AppEvent::KillContainer(id) => self.request_kill_container(id),
+                    AppEvent::RemoveContainer(id) => self.request_remove_container(id),
+                    AppEvent::GoToContainerDetails(id) => self.request_container_details_open(id),
+                    AppEvent::UpdateVolumes => self.request_volumes(),
+                    AppEvent::RemoveVolume(name, force) => self.request_remove_volume(name, force),
+                    AppEvent::UpdateNetworks => self.request_networks(),
+                    AppEvent::RemoveNetwork(name) => self.request_remove_network(name),
+                    AppEvent::UpdateImages => self.request_images(),
+                    AppEvent::RemoveImage(id, force) => self.request_remove_image(id, force),
+                    AppEvent::Back => {
+                        self.details_requested = false;
+                        self.container_info = None;
+                    }
+                }
+            }
         }
         Ok(())
     }
@@ -232,12 +258,13 @@ impl<C: DockerApi> App<C> {
     }
 
     fn report_err(&mut self, tab: SelectedTab, err: &DockerError) {
-        match tab {
+        let changed = match tab {
             SelectedTab::Containers => self.container_table.show_err(err),
             SelectedTab::Volumes => self.volume_table.show_err(err),
             SelectedTab::Networks => self.network_table.show_err(err),
             SelectedTab::Images => self.image_table.show_err(err),
-        }
+        };
+        self.dirty |= changed;
     }
 
     /// Unwraps a Docker result, reporting failures into `tab`'s footer.
@@ -268,6 +295,7 @@ impl<C: DockerApi> App<C> {
             SelectedTab::Networks => self.network_table.begin_pending_op(),
             SelectedTab::Images => self.image_table.begin_pending_op(),
         }
+        self.dirty = true;
     }
 
     fn end_action(&mut self, tab: SelectedTab) {
@@ -277,6 +305,7 @@ impl<C: DockerApi> App<C> {
             SelectedTab::Networks => self.network_table.end_pending_op(),
             SelectedTab::Images => self.image_table.end_pending_op(),
         }
+        self.dirty = true;
     }
 
     /// Runs a Docker operation off the event loop; its outcome comes back as `Event::Docker`.
@@ -428,7 +457,8 @@ impl<C: DockerApi> App<C> {
             DockerOutcome::ContainersListed(result) => {
                 self.pending.containers = false;
                 if let Some(list) = self.ok_or_report(SelectedTab::Containers, result) {
-                    self.container_table
+                    self.dirty |= self
+                        .container_table
                         .update_with_items(ContainerTableRow::from_list(list));
                 }
             }
@@ -437,21 +467,24 @@ impl<C: DockerApi> App<C> {
                 if let Some(response) = self.ok_or_report(SelectedTab::Volumes, result)
                     && let Some(volumes) = response.volumes
                 {
-                    self.volume_table
+                    self.dirty |= self
+                        .volume_table
                         .update_with_items(VolumeTableRow::from_list(volumes));
                 }
             }
             DockerOutcome::NetworksListed(result) => {
                 self.pending.networks = false;
                 if let Some(list) = self.ok_or_report(SelectedTab::Networks, result) {
-                    self.network_table
+                    self.dirty |= self
+                        .network_table
                         .update_with_items(NetworkTableRow::from_list(list));
                 }
             }
             DockerOutcome::ImagesListed(result) => {
                 self.pending.images = false;
                 if let Some(list) = self.ok_or_report(SelectedTab::Images, result) {
-                    self.image_table
+                    self.dirty |= self
+                        .image_table
                         .update_with_items(ImageTableRow::from_list(list));
                 }
             }
@@ -475,8 +508,9 @@ impl<C: DockerApi> App<C> {
                     let mut container_info_block = ContainerInfoBlock::default();
                     container_info_block.update_data(data);
                     self.container_info = Some(Box::new(container_info_block));
+                    self.dirty = true;
                 } else if let Some(block) = self.container_info.as_mut() {
-                    block.update_data(data);
+                    self.dirty |= block.update_data(data);
                 }
             }
             DockerOutcome::ActionCompleted { resource, result } => {
@@ -534,8 +568,8 @@ impl SelectedTab {
 mod tests {
     use super::*;
     use bollard::secret::{
-        ContainerInspectResponse, ContainerSummary, ImageSummary, Network, Volume,
-        VolumeListResponse,
+        ContainerInspectResponse, ContainerStateStatusEnum, ContainerSummary, ImageSummary,
+        Network, Volume, VolumeListResponse,
     };
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use std::sync::{Arc, Mutex};
@@ -1108,5 +1142,153 @@ mod tests {
             SelectedTab::Containers.title().to_string(),
             "  Containers  "
         );
+    }
+
+    #[test]
+    fn app_starts_dirty() {
+        let mock = MockDockerClient::default();
+        let app = App::with_client(mock);
+        assert!(app.dirty);
+    }
+
+    #[tokio::test]
+    async fn tick_does_not_mark_dirty() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+        app.dirty = false;
+
+        app.events.sender().send(Event::Tick).unwrap();
+        app.process_next_event().await.unwrap();
+
+        assert!(!app.dirty);
+    }
+
+    #[tokio::test]
+    async fn key_event_marks_dirty() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+        app.dirty = false;
+
+        app.events
+            .sender()
+            .send(Event::Crossterm(KeyEvent::from(KeyCode::Right)))
+            .unwrap();
+        app.process_next_event().await.unwrap();
+
+        assert!(app.dirty);
+    }
+
+    #[tokio::test]
+    async fn resize_event_marks_dirty() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+        app.dirty = false;
+
+        app.events.sender().send(Event::Resize).unwrap();
+        app.process_next_event().await.unwrap();
+
+        assert!(app.dirty);
+        assert!(app.running);
+    }
+
+    #[test]
+    fn unchanged_container_list_does_not_mark_dirty() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        app.apply_docker_outcome(DockerOutcome::ContainersListed(Ok(vec![
+            container_summary("a"),
+        ])));
+        app.dirty = false;
+
+        app.apply_docker_outcome(DockerOutcome::ContainersListed(Ok(vec![
+            container_summary("a"),
+        ])));
+        assert!(!app.dirty);
+
+        app.apply_docker_outcome(DockerOutcome::ContainersListed(Ok(vec![
+            container_summary("a"),
+            container_summary("b"),
+        ])));
+        assert!(app.dirty);
+    }
+
+    #[test]
+    fn list_error_marks_dirty_once() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        app.apply_docker_outcome(DockerOutcome::ContainersListed(Err(
+            DockerError::DaemonUnreachable {
+                details: "connection refused".to_string(),
+            },
+        )));
+        assert!(app.dirty);
+        app.dirty = false;
+
+        app.apply_docker_outcome(DockerOutcome::ContainersListed(Err(
+            DockerError::DaemonUnreachable {
+                details: "connection refused".to_string(),
+            },
+        )));
+        assert!(!app.dirty);
+    }
+
+    #[tokio::test]
+    async fn action_request_and_completion_mark_dirty() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+        app.dirty = false;
+
+        app.request_stop_container("container-id".to_string());
+        assert!(app.dirty);
+        app.dirty = false;
+
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Containers,
+            result: Ok(()),
+        });
+        assert!(app.dirty);
+    }
+
+    #[tokio::test]
+    async fn container_info_refresh_with_identical_data_does_not_mark_dirty() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        app.request_container_details_open("container-id".to_string());
+        let inspect = ContainerInspectResponse {
+            id: Some("container-id".to_string()),
+            state: Some(bollard::secret::ContainerState {
+                status: Some(ContainerStateStatusEnum::RUNNING),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        app.apply_docker_outcome(DockerOutcome::ContainerInspected {
+            open_details: true,
+            result: Ok(Box::new(inspect.clone())),
+        });
+        assert!(app.container_info.is_some());
+        app.dirty = false;
+
+        app.apply_docker_outcome(DockerOutcome::ContainerInspected {
+            open_details: false,
+            result: Ok(Box::new(inspect.clone())),
+        });
+        assert!(!app.dirty);
+
+        let changed_inspect = ContainerInspectResponse {
+            state: Some(bollard::secret::ContainerState {
+                status: Some(ContainerStateStatusEnum::EXITED),
+                ..Default::default()
+            }),
+            ..inspect
+        };
+        app.apply_docker_outcome(DockerOutcome::ContainerInspected {
+            open_details: false,
+            result: Ok(Box::new(changed_inspect)),
+        });
+        assert!(app.dirty);
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -4,18 +4,20 @@ use bollard::secret::{
 use color_eyre::eyre::{OptionExt, Result};
 use crossterm::event::KeyEventKind;
 use futures::{FutureExt, StreamExt};
-use ratatui::crossterm::event::{Event::Key, KeyEvent};
+use ratatui::crossterm::event::{Event::Key, Event::Resize, KeyEvent};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
 use crate::docker::error::DockerResult;
 
-const TICK_FPS: f64 = 30.0;
+/// Ticks now only drive Docker refresh scheduling, not rendering.
+const TICK_FPS: f64 = 5.0;
 
 #[derive(Clone, Debug)]
 pub enum Event {
     Tick,
     Crossterm(KeyEvent),
+    Resize,
     App(AppEvent),
     Docker(DockerOutcome),
 }
@@ -130,10 +132,8 @@ impl EventTask {
                 _ = self.sender.closed() => break,
                 _ = tick_delay => self.send(Event::Tick),
                 Some(Ok(event)) = crossterm_event => {
-                    if let Key(key) = event
-                        && key.kind == KeyEventKind::Press
-                    {
-                        self.send(Event::Crossterm(key))
+                    if let Some(event) = map_crossterm_event(event) {
+                        self.send(event)
                     }
                 }
             };
@@ -144,6 +144,17 @@ impl EventTask {
 
     fn send(&self, event: Event) {
         let _ = self.sender.send(event);
+    }
+}
+
+/// Maps a raw crossterm event to the subset of `Event`s the app cares about.
+/// Only key-press events and terminal resizes are forwarded; everything else
+/// (key release/repeat, mouse, focus, paste) is discarded.
+fn map_crossterm_event(event: crossterm::event::Event) -> Option<Event> {
+    match event {
+        Key(key) if key.kind == KeyEventKind::Press => Some(Event::Crossterm(key)),
+        Resize(..) => Some(Event::Resize),
+        _ => None,
     }
 }
 
@@ -159,6 +170,29 @@ mod tests {
 
         let event = handler.next().await.unwrap();
         assert!(matches!(event, Event::App(AppEvent::Quit)));
+    }
+
+    #[test]
+    fn map_crossterm_event_forwards_key_press_and_resize_only() {
+        use crossterm::event::{KeyCode, KeyModifiers};
+
+        let key_press =
+            crossterm::event::Event::Key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
+        assert!(matches!(
+            map_crossterm_event(key_press),
+            Some(Event::Crossterm(_))
+        ));
+
+        let mut key_release = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
+        key_release.kind = KeyEventKind::Release;
+        assert!(map_crossterm_event(Key(key_release)).is_none());
+
+        assert!(matches!(
+            map_crossterm_event(Resize(80, 24)),
+            Some(Event::Resize)
+        ));
+
+        assert!(map_crossterm_event(crossterm::event::Event::FocusGained).is_none());
     }
 
     #[tokio::test]

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -6,7 +6,7 @@ use ratatui::{
 };
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const REFRESH_AFTER_TICK: u8 = 10;
+const REFRESH_EVERY_TICKS: u8 = 2;
 
 #[derive(Default, Clone)]
 pub struct RefreshTicker {
@@ -14,14 +14,16 @@ pub struct RefreshTicker {
 }
 
 impl RefreshTicker {
-    /// Returns true once every `REFRESH_AFTER_TICK + 2` ticks, resetting the counter.
+    /// Returns true once every `REFRESH_EVERY_TICKS` ticks, resetting the counter.
+    /// At `TICK_FPS = 5.0` that is every 400 ms, matching the previous cadence of
+    /// every 12 ticks at 30 FPS.
     pub fn should_refresh(&mut self) -> bool {
-        if self.skipped_tick_count <= REFRESH_AFTER_TICK {
-            self.skipped_tick_count += 1;
-            false
-        } else {
+        self.skipped_tick_count += 1;
+        if self.skipped_tick_count >= REFRESH_EVERY_TICKS {
             self.skipped_tick_count = 0;
             true
+        } else {
+            false
         }
     }
 }
@@ -143,17 +145,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn refresh_ticker_fires_every_twelfth_tick() {
+    fn refresh_ticker_fires_every_second_tick() {
         let mut ticker = RefreshTicker::default();
 
-        for _ in 0..11 {
-            assert!(!ticker.should_refresh());
-        }
+        assert!(!ticker.should_refresh());
         assert!(ticker.should_refresh());
 
-        for _ in 0..11 {
-            assert!(!ticker.should_refresh());
-        }
+        assert!(!ticker.should_refresh());
         assert!(ticker.should_refresh());
     }
 

--- a/src/ui/container_info_block.rs
+++ b/src/ui/container_info_block.rs
@@ -22,9 +22,11 @@ pub struct ContainerInfoBlock {
     data: ContainerData,
     scroll_info: ScrollInfo,
     ticker: RefreshTicker,
+    content_lines: Vec<Line<'static>>,
+    max_line_width: usize,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct ContainerData {
     id: String,
     name: String,
@@ -88,19 +90,15 @@ impl ScrollableInfoBlock for ContainerInfoBlock {
         let horizontal_layout = Layout::horizontal([Min(0), Length(1)]);
         let [info_area, vertical_scrollbar_area] = horizontal_layout.areas(content_area);
 
-        let content_lines = get_content_as_lines(&self.data);
-
-        let max_horizontal = content_lines.iter().fold(0, |max, line| {
-            let line_len = line.to_string().len();
-            if line_len > max { line_len } else { max }
-        });
-
-        self.scroll_info.max_horizontal =
-            max_horizontal.saturating_sub(info_area.width as usize - 2);
-        self.scroll_info.max_vertical = content_lines
+        self.scroll_info.max_horizontal = self
+            .max_line_width
+            .saturating_sub(info_area.width as usize - 2);
+        self.scroll_info.max_vertical = self
+            .content_lines
             .len()
             .saturating_sub(info_area.height as usize - 2);
 
+        let content_lines = self.content_lines.clone();
         self.render_content(frame, info_area, content_lines);
 
         self.scroll_info.vertical_state = self
@@ -148,8 +146,13 @@ impl ScrollableInfoBlock for ContainerInfoBlock {
         Ok(event)
     }
 
-    fn update_data(&mut self, data: Self::Data) {
+    fn update_data(&mut self, data: Self::Data) -> bool {
+        if self.data == data {
+            return false;
+        }
         self.data = data;
+        self.rebuild_content_cache();
+        true
     }
 
     fn get_scroll_info(&mut self) -> &mut super::info_block::ScrollInfo {
@@ -158,6 +161,14 @@ impl ScrollableInfoBlock for ContainerInfoBlock {
 }
 
 impl ContainerInfoBlock {
+    fn rebuild_content_cache(&mut self) {
+        self.content_lines = get_content_as_lines(&self.data);
+        self.max_line_width = self.content_lines.iter().fold(0, |max, line| {
+            let line_len = line.to_string().len();
+            if line_len > max { line_len } else { max }
+        });
+    }
+
     fn render_content(&mut self, frame: &mut Frame, area: Rect, lines: Vec<Line<'static>>) {
         let block_style = Style::new().fg(tailwind::BLUE.c400);
 
@@ -511,7 +522,7 @@ mod tests {
     }
 
     #[test]
-    fn tick_fires_exactly_once_every_twelve_ticks() {
+    fn tick_fires_once_every_two_ticks() {
         let mut block = ContainerInfoBlock {
             data: ContainerData::from(container_with_id("container-id")),
             ..Default::default()
@@ -524,7 +535,7 @@ mod tests {
             }
         }
 
-        assert_eq!(fired, 1);
+        assert_eq!(fired, 6);
     }
 
     #[test]
@@ -583,5 +594,50 @@ mod tests {
         let labels_index = lines.iter().position(|l| l.starts_with("Labels:")).unwrap();
         assert!(lines[labels_index + 1].contains("a: first"));
         assert!(lines[labels_index + 2].contains("z: last"));
+    }
+
+    #[test]
+    fn update_data_caches_lines_and_max_width() {
+        let mut block = ContainerInfoBlock::default();
+
+        let changed = block.update_data(ContainerData::from(container_with_id("abc")));
+        assert!(changed);
+
+        assert!(!block.content_lines.is_empty());
+        assert!(
+            block
+                .content_lines
+                .iter()
+                .any(|l| l.to_string().starts_with("ID: abc"))
+        );
+        assert_eq!(
+            block.max_line_width,
+            block
+                .content_lines
+                .iter()
+                .map(|l| l.to_string().len())
+                .max()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn update_data_with_identical_data_is_a_no_op() {
+        let mut block = ContainerInfoBlock::default();
+
+        let changed = block.update_data(ContainerData::from(container_with_id("abc")));
+        assert!(changed);
+
+        let changed_again = block.update_data(ContainerData::from(container_with_id("abc")));
+        assert!(!changed_again);
+
+        let changed_different = block.update_data(ContainerData::from(container_with_id("xyz")));
+        assert!(changed_different);
+        assert!(
+            block
+                .content_lines
+                .iter()
+                .any(|l| l.to_string().starts_with("ID: xyz"))
+        );
     }
 }

--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -16,6 +16,7 @@ pub struct ContainerTable {
     info: ResourceTableInfo<ContainerTableRow>,
 }
 
+#[derive(PartialEq)]
 pub struct ContainerTableRow {
     id: String,
     name: String,

--- a/src/ui/image_table.rs
+++ b/src/ui/image_table.rs
@@ -18,7 +18,7 @@ pub struct ImageTable {
     info: ResourceTableInfo<ImageTableRow>,
 }
 
-#[derive(Default)]
+#[derive(Default, PartialEq)]
 pub struct ImageTableRow {
     id: String,
     tags: String,

--- a/src/ui/info_block.rs
+++ b/src/ui/info_block.rs
@@ -41,7 +41,8 @@ pub trait ScrollableInfoBlock {
 
     fn tick(&mut self) -> Result<Option<AppEvent>>;
 
-    fn update_data(&mut self, data: Self::Data);
+    /// Returns true when the visible content changed.
+    fn update_data(&mut self, data: Self::Data) -> bool;
 
     fn get_scroll_info(&mut self) -> &mut ScrollInfo;
 
@@ -118,7 +119,9 @@ mod tests {
             Ok(None)
         }
 
-        fn update_data(&mut self, _data: Self::Data) {}
+        fn update_data(&mut self, _data: Self::Data) -> bool {
+            false
+        }
 
         fn get_scroll_info(&mut self) -> &mut ScrollInfo {
             &mut self.scroll

--- a/src/ui/network_table.rs
+++ b/src/ui/network_table.rs
@@ -16,7 +16,7 @@ pub struct NetworkTable {
     info: ResourceTableInfo<NetworkTableRow>,
 }
 
-#[derive(Default)]
+#[derive(Default, PartialEq)]
 pub struct NetworkTableRow {
     id: String,
     name: String,

--- a/src/ui/resource_table.rs
+++ b/src/ui/resource_table.rs
@@ -45,7 +45,7 @@ impl<RowType> Default for ResourceTableInfo<RowType> {
 }
 
 /// A single row of a `ResourceTable`, projected from a source Docker API type.
-pub trait ResourceRow: Sized {
+pub trait ResourceRow: Sized + PartialEq {
     type Source;
 
     fn from_source(source: &Self::Source) -> Self;
@@ -171,14 +171,18 @@ pub trait ResourceTable {
             .position(table_info.scroll);
     }
 
-    fn update_with_items(&mut self, items: Vec<Self::RowType>) {
+    /// Replaces the rows and reports whether anything visible changed.
+    fn update_with_items(&mut self, items: Vec<Self::RowType>) -> bool {
         let table_info = self.table_info_mut();
+        let changed = table_info.items != items;
         let is_empty_before_update = table_info.items.is_empty();
         table_info.items = items;
 
         if is_empty_before_update && !table_info.items.is_empty() {
             self.select_row(0);
         }
+
+        changed
     }
 
     fn render_table(&mut self, frame: &mut Frame, area: Rect) {
@@ -293,8 +297,13 @@ pub trait ResourceTable {
         }
     }
 
-    fn show_err(&mut self, err: &DockerError) {
-        self.table_info_mut().err = Some(format!("[ERR] {err}"));
+    /// Sets the footer error message and reports whether it differs from the
+    /// previously shown error.
+    fn show_err(&mut self, err: &DockerError) -> bool {
+        let message = format!("[ERR] {err}");
+        let changed = self.table_info().err.as_deref() != Some(message.as_str());
+        self.table_info_mut().err = Some(message);
+        changed
     }
 
     fn begin_pending_op(&mut self) {
@@ -312,7 +321,7 @@ mod tests {
     use super::*;
     use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
 
-    #[derive(Default, Clone)]
+    #[derive(Default, Clone, PartialEq)]
     struct TestRow {
         label: String,
         visible: bool,
@@ -442,7 +451,7 @@ mod tests {
     fn show_err_formats_typed_error_into_footer() {
         let mut table = TestTable::default();
 
-        table.show_err(&DockerError::Conflict {
+        let changed = table.show_err(&DockerError::Conflict {
             message: "network foo has active endpoints".into(),
         });
 
@@ -450,6 +459,26 @@ mod tests {
             table.info.err,
             Some("[ERR] Conflict: network foo has active endpoints".to_string())
         );
+        assert!(changed);
+
+        let changed_again = table.show_err(&DockerError::Conflict {
+            message: "network foo has active endpoints".into(),
+        });
+        assert!(!changed_again);
+    }
+
+    #[test]
+    fn update_with_items_reports_change_only_when_rows_differ() {
+        let mut table = TestTable::default();
+
+        let changed = table.update_with_items(rows(&[("a", true), ("b", true)]));
+        assert!(changed);
+
+        let changed_again = table.update_with_items(rows(&[("a", true), ("b", true)]));
+        assert!(!changed_again);
+
+        let changed_different = table.update_with_items(rows(&[("a", true), ("c", true)]));
+        assert!(changed_different);
     }
 
     #[test]

--- a/src/ui/volume_table.rs
+++ b/src/ui/volume_table.rs
@@ -13,7 +13,7 @@ pub struct VolumeTable {
     info: ResourceTableInfo<VolumeTableRow>,
 }
 
-#[derive(Default)]
+#[derive(Default, PartialEq)]
 pub struct VolumeTableRow {
     name: String,
     driver: String,


### PR DESCRIPTION
## Summary

Fixes the constant 30 FPS full-redraw loop described in #22.

- **Dirty-flag rendering** (`src/app.rs`): `terminal.draw` now runs only when something visible changed — a key press, a terminal resize, a pending-op / error footer change, or Docker data that actually differs from what is on screen. An idle dashboard no longer repaints at all.
- **Tick rate lowered to 5 FPS** (`src/event.rs`): ticks now only schedule Docker refreshes. `RefreshTicker` fires every 2nd tick, preserving the previous ~400 ms data-refresh cadence exactly.
- **Resize events are now forwarded** (`Event::Resize`): previously they were dropped and the per-tick redraw hid that; with conditional rendering they must (and do) trigger a repaint.
- **Change detection at the data boundary**: `update_with_items`, `show_err` and `update_data` return whether anything visible changed; row types and `ContainerData` derive `PartialEq`. Identical refresh results (including a repeating daemon-unreachable error) no longer cause repaints.
- **Container detail cache** (`src/ui/container_info_block.rs`): formatted lines and max line width are built once in `update_data` and invalidated only when the inspect data differs, instead of cloning every field and reallocating all lines each frame.
- Table row-cell caching was considered and intentionally skipped: after the dirty flag, cells are only rebuilt when a draw happens, which is exactly when a cache would be invalidated anyway.

Closes #22

## Test plan

- [x] `cargo test` — 105 passed (8 new dirty-flag tests in `app.rs`, cache tests in `container_info_block.rs`, event-mapping test in `event.rs`, change-report tests in `resource_table.rs`)
- [x] `cargo clippy -- -D warnings` clean, `cargo fmt` applied
- [ ] Manual: idle CPU near zero; list still updates within ~0.5 s after `docker stop` outside the app; resize reflows immediately; navigation/scrolling feel instant; error footer appears once and clears on key press

🤖 Generated with [Claude Code](https://claude.com/claude-code)