### PR TITLE
fix: let Esc and arrow keys fall through on the containers tab

### DIFF
--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -102,7 +102,7 @@ impl ResourceTable for ContainerTable {
                 ('x', Some(id)) => KeyOutcome::Handled(Some(AppEvent::KillContainer(id))),
                 _ => KeyOutcome::Fallthrough,
             },
-            _ => KeyOutcome::Handled(None),
+            _ => KeyOutcome::Fallthrough,
         };
 
         Ok(outcome)
@@ -359,6 +359,42 @@ mod tests {
             KeyOutcome::Handled(Some(AppEvent::RemoveContainer(got))) => assert_eq!(got, id),
             _ => panic!("expected RemoveContainer"),
         }
+    }
+
+    #[test]
+    fn esc_and_arrow_keys_fall_through_to_shared_navigation() {
+        let mut table = ContainerTable::default();
+        let rows = ContainerTableRow::from_list(vec![
+            summary_with_ports("running-id", "running"),
+            summary_with_ports("other-id", "running"),
+        ]);
+        table.update_with_items(rows);
+        table.info.row_heights = vec![DEFAULT_ROW_HEIGHT, DEFAULT_ROW_HEIGHT];
+        table.select_row(0);
+
+        for code in [KeyCode::Esc, KeyCode::Up, KeyCode::Down] {
+            match table
+                .handle_resource_key_event(KeyEvent::from(code))
+                .unwrap()
+            {
+                KeyOutcome::Fallthrough => {}
+                _ => panic!("expected {code:?} to fall through to shared navigation"),
+            }
+        }
+
+        // End-to-end through the shared handler: Esc quits, arrows move the selection.
+        let event = table
+            .handle_key_event(KeyEvent::from(KeyCode::Esc))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::Quit)));
+
+        table
+            .handle_key_event(KeyEvent::from(KeyCode::Down))
+            .unwrap();
+        assert_eq!(table.table_info().state.selected(), Some(1));
+
+        table.handle_key_event(KeyEvent::from(KeyCode::Up)).unwrap();
+        assert_eq!(table.table_info().state.selected(), Some(0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

On the Containers tab (the default tab), `Esc` did not quit the application and the `Up`/`Down` arrow keys did not move the selection, while the vim-style keys (`q`, `j`, `k`) worked.

The catch-all arm in `ContainerTable::handle_resource_key_event` returned `KeyOutcome::Handled(None)`, swallowing every unmatched non-character key before it could reach the shared navigation handler (`handle_nav_key_event`), which maps `Esc`/`q` to quit and `Up`/`Down` to row navigation. The volume, network, and image tables already return `KeyOutcome::Fallthrough` there.

## Changes

- Change the catch-all arm to `KeyOutcome::Fallthrough`, matching the other resource tables.
- Add a regression test verifying that `Esc`, `Up`, and `Down` fall through, and that end-to-end through `handle_key_event` Esc emits `AppEvent::Quit` and the arrows move the selection.

## Test plan

- `cargo test` — 106 passed, including the new `esc_and_arrow_keys_fall_through_to_shared_navigation` test
- `cargo clippy -- -D warnings` — clean
- `cargo fmt` — applied

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
