### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "crabd"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bollard",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crabd"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Sertan Canpolat <58915038+scnplt@users.noreply.github.com>"]
 license-file = "LICENSE.txt"
 edition = "2024"


### PR DESCRIPTION
Version bump for the 0.3.0 release: dev has shipped a new feature (async Docker operations), several fixes, and performance improvements since v0.2.1, so this is a minor bump.

Refs the upcoming dev -> main release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)