### PR TITLE
release: v0.3.0

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,0 +1,23 @@
+---
+name: implementer
+description: Plan-faithful coding agent for crabd. Use to implement a plan produced by the planner agent (or an explicit plan from the user). Writes Rust code strictly within the plan's scope and verifies with cargo build/test/clippy/fmt.
+model: sonnet
+tools: Read, Write, Edit, Grep, Glob, Bash
+---
+
+You are the implementation agent for crabd, a Rust (edition 2024) terminal UI Docker manager built on ratatui, crossterm, tokio, and bollard.
+
+You implement an existing plan. You do not design.
+
+Rules:
+
+1. **Follow the plan exactly.** Implement the steps in order, touching only the files and items the plan names. If the plan turns out to be wrong or impossible (missing API, type conflict, borrow-checker dead end), STOP and report the problem with specifics — do not invent an alternative design on your own.
+2. **Stay in scope.** No drive-by refactors, no renaming, no extra features, no dependency additions the plan doesn't call for.
+3. **Match existing style.** Mirror the surrounding code's idioms, error handling (color-eyre `Result`), module layout (`src/docker/`, `src/ui/`), and comment density.
+4. **Verify every step.** After each meaningful change run:
+   - `cargo build`
+   - `cargo test`
+   - `cargo clippy -- -D warnings`
+   - `cargo fmt`
+   Fix any failures you introduced before moving to the next step.
+5. **Report honestly.** Finish with a summary of: steps completed, files changed, verification results (paste failing output verbatim if anything fails), and any deviations from the plan with the reason.

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,0 +1,24 @@
+---
+name: planner
+description: Planning specialist for crabd. Use PROACTIVELY before implementing any non-trivial feature, refactor, or bug fix. Produces a concrete, step-by-step implementation plan (files, functions, order of changes, test strategy) but NEVER writes or edits code itself.
+model: opus
+tools: Read, Grep, Glob, Bash
+---
+
+You are the planning agent for crabd, a Rust (edition 2024) terminal UI Docker manager built on ratatui, crossterm, tokio, and bollard.
+
+Your job is to produce implementation plans. You are read-only: never create, edit, or delete project files — the plan itself is your only output.
+
+When given a task:
+
+1. Explore the relevant code first (`src/main.rs`, `src/ui/`, `src/docker/`, `Cargo.toml`) so the plan matches how the codebase actually works — its event loop, state handling, and widget patterns.
+2. Identify constraints: async boundaries (tokio), Docker API surface (bollard), TUI rendering (ratatui), error handling style (color-eyre).
+3. Produce a plan with:
+   - **Goal** — one-sentence restatement of the task.
+   - **Steps** — numbered, ordered, each naming the exact file(s) and function(s)/struct(s) to touch and what changes.
+   - **New items** — any new modules, dependencies (with version), or types, with justification.
+   - **Test strategy** — which unit/integration tests to add or update (`cargo test`), and how to manually verify in the TUI.
+   - **Risks** — what could break (rendering, async deadlocks, Docker API errors) and how the plan mitigates it.
+4. Keep the plan minimal: smallest change that satisfies the task, consistent with existing patterns. Do not propose speculative refactors.
+
+The plan must be precise enough that an implementer can follow it without making design decisions of their own.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,50 @@
+# Git Workflow
+
+## Branching Model
+
+| Branch | Role | Merged from |
+|--------|------|-------------|
+| `main` | Production / release. Only released code. | `dev` -> `main` (release PR) or `hotfix/*` -> `main` |
+| `dev` | Integration / development branch. Default base branch. | `feat/*`, `fix/*`, ... -> `dev` PR |
+| `<type>/<slug>` | A single feature or fix. Short-lived. | Deleted after merge |
+
+Rules:
+
+- **Every feature lives on its own branch.** Never commit directly to `dev` or `main`.
+- Feature branches are **cut from `dev`** and return to **`dev`** through a PR:
+  ```bash
+  git checkout dev && git pull
+  git checkout -b feat/<slug>
+  # ... commits ...
+  git push -u origin feat/<slug>
+  gh pr create --base dev
+  ```
+- Branch names reuse the commit types: `feat/`, `fix/`, `refactor/`, `docs/`, `test/`,
+  `chore/`, `perf/`, `ci/`. Example: `feat/image-search`, `fix/empty-list-panic`.
+- **Release:** `dev` -> `main` PR. A merge into `main` means "releasable" and is tagged
+  `vX.Y.Z`.
+- **Hotfix:** only when a release is broken — cut `hotfix/<slug>` from `main`, merge into
+  `main`, then merge `main` back into `dev` so the fix is not lost.
+- Delete merged feature branches locally and on the remote.
+- Treat `main` and `dev` as protected: no force push, no merge without a PR.
+
+## Commit Message Format
+
+```
+<type>: <description>
+
+<optional body explaining why, not what>
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`
+
+## Pull Request Workflow
+
+When creating PRs:
+
+1. Analyze the full commit history of the branch (not just the latest commit)
+2. Use `git diff dev...HEAD` to see all changes
+3. Draft a comprehensive PR summary
+4. Include a test plan
+5. Push with `-u` on the first push of a new branch
+6. A PR that closes an issue carries a bare `Closes #N` line in its body

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -38,6 +38,14 @@ Rules:
 
 Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`
 
+## Issue Workflow
+
+When creating issues:
+
+- Always add the appropriate label(s) at creation time (`gh issue create --label ...`).
+  Available labels include `bug`, `enhancement`, `documentation`, `question`,
+  `good first issue`, `help wanted`; check `gh label list` when unsure.
+
 ## Pull Request Workflow
 
 When creating PRs:
@@ -48,3 +56,7 @@ When creating PRs:
 4. Include a test plan
 5. Push with `-u` on the first push of a new branch
 6. A PR that closes an issue carries a bare `Closes #N` line in its body
+7. Always link the PR to its related issue (`Closes #N` for fixes, `Refs #N`
+   for partial work) and add the matching label(s) to the PR as well
+   (`gh pr create --label ...` / `gh pr edit --add-label ...`), mirroring the
+   issue's labels (e.g. `bug` for a fix, `enhancement` for a feature)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,28 @@
-name: Cargo Build
+name: CI
 
 on:
+  push:
+    branches: [main, dev]
   pull_request:
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  check:
+    name: fmt, clippy, build, test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain:
-          - stable
     steps:
       - uses: actions/checkout@v4
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: cargo build --verbose
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Build
+        run: cargo build --verbose
+      - name: Test
+        run: cargo test --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   check:
-    name: fmt, clippy, build, test
+    name: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 debug/
 target/
+.claude/PRPs/
 
 **/*.rs.bak
 *.pdb

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# crabd — terminal-based Docker resource manager (Rust, edition 2024)
+
+TUI app built with ratatui + crossterm, async runtime tokio, Docker API via bollard.
+
+## Commands
+
+- Build: `cargo build`
+- Test: `cargo test`
+- Lint: `cargo clippy -- -D warnings`
+- Format: `cargo fmt`
+- Run: `cargo run` (interactive TUI; requires a reachable Docker daemon)
+
+## Conventions
+
+- Work on the `dev` branch; PRs target `main`.
+- Keep clippy clean (`-D warnings`) and run `cargo fmt` before committing.
+- Source layout: `src/docker/` (Docker/bollard integration), `src/ui/` (ratatui widgets), `src/main.rs` (entry point and event loop).
+
+## Workflow
+
+- For non-trivial features or refactors, plan first with the `planner` agent (Opus), then implement with the `implementer` agent (Sonnet), which must follow the approved plan.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,15 @@ TUI app built with ratatui + crossterm, async runtime tokio, Docker API via boll
 
 ## Conventions
 
-- Work on the `dev` branch; PRs target `main`.
+- **Language rule**: everything in this repository is written in English — code, identifiers, comments, documentation, commit messages, issues, PRs, and any other text. (Conversation with the maintainer may be in Turkish, but repository content is always English.)
 - Keep clippy clean (`-D warnings`) and run `cargo fmt` before committing.
 - Source layout: `src/docker/` (Docker/bollard integration), `src/ui/` (ratatui widgets), `src/main.rs` (entry point and event loop).
+
+## Branching
+
+`main` = production/release, `dev` = integration, every feature on its own
+`<type>/<slug>` branch cut from `dev`. Never commit directly to `main` or `dev`.
+Full model: `.claude/rules/git-workflow.md`. Contributor-facing version: `CONTRIBUTING.md`.
 
 ## Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,15 @@ keep the history clean and reviews cheap.
 ## Before you write code
 
 For anything more than a small fix, open an issue first so the change can be
-discussed before you invest time in it.
+discussed before you invest time in it. Label the issue when you open it
+(`bug`, `enhancement`, `documentation`, ...).
+
+## Pull requests
+
+- Link the PR to its issue: a bare `Closes #N` line in the body for a PR that
+  finishes the issue, `Refs #N` for partial work.
+- Mirror the issue's labels on the PR (e.g. `bug` for a fix, `enhancement`
+  for a feature).
 
 ## Language
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing
+
+Thanks for your interest in crabd! Contributions are welcome. The notes below
+keep the history clean and reviews cheap.
+
+## Before you write code
+
+For anything more than a small fix, open an issue first so the change can be
+discussed before you invest time in it.
+
+## Language
+
+**Everything in this repository is English.** Code comments, doc comments,
+identifiers, log and error messages, markdown, commit messages, branch names,
+PR titles and bodies, issue text. This holds regardless of the language a
+discussion happens in.
+
+## Branching
+
+| Branch | Role |
+|---|---|
+| `main` | Production / release. Tagged `vX.Y.Z`. |
+| `dev` | Integration. The default base for pull requests. |
+| `<type>/<slug>` | One feature or fix. Short-lived, deleted after merge. |
+
+Never commit directly to `main` or `dev`. Cut from `dev`, return to `dev`:
+
+```bash
+git checkout dev && git pull
+git checkout -b feat/my-change
+# ... commits ...
+git push -u origin feat/my-change
+gh pr create --base dev
+```
+
+Branch prefixes reuse the commit types: `feat/`, `fix/`, `refactor/`, `docs/`,
+`test/`, `chore/`, `perf/`, `ci/`.
+
+## Commits
+
+```
+<type>: <description>
+
+<optional body explaining why, not what>
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`.
+
+Keep commits small enough to review on their own. The body is for the reason a
+change is correct — the diff already says what changed.
+
+## Gates
+
+Every one of these must pass before a pull request is ready:
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo build
+cargo test
+```
+
+Testing UI changes also means running the TUI (`cargo run`) against a real
+Docker daemon and exercising the affected screens.
+
+## License
+
+By contributing you agree your work is licensed under the
+[Apache License 2.0](LICENSE.txt), the same as the rest of the project.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,10 +99,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bitflags"
-version = "2.9.0"
+name = "bit-set"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bollard"
@@ -105,7 +159,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -125,22 +179,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
-name = "bytes"
-version = "1.10.1"
+name = "by_address"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
-name = "cassowary"
-version = "0.3.0"
+name = "bytemuck"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "castaway"
@@ -162,9 +231,15 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
@@ -176,7 +251,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -208,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -221,10 +296,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crabd"
@@ -242,13 +335,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossterm"
-version = "0.28.1"
+name = "critical-section"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "crossterm_winapi",
+ "derive_more",
+ "document-features",
  "futures-core",
  "mio",
  "parking_lot",
@@ -265,6 +366,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
 ]
 
 [[package]]
@@ -288,7 +409,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -299,17 +420,55 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
-name = "deranged"
-version = "0.4.1"
+name = "deltae"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -320,8 +479,23 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -346,6 +520,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +539,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,9 +579,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -432,7 +648,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -466,6 +682,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +731,23 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -753,7 +1019,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -827,14 +1093,14 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -856,6 +1122,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,21 +1146,42 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "line-clipping"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
+dependencies = [
+ "bitflags 2.13.1",
+]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -897,11 +1201,21 @@ checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
 ]
 
 [[package]]
@@ -909,6 +1223,27 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -932,10 +1267,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
+name = "nix"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "num-traits"
@@ -944,6 +1313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -962,10 +1340,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
+
+[[package]]
+name = "palette"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
+dependencies = [
+ "approx",
+ "libm",
+ "palette_derive",
+ "palette_math",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "parking_lot"
@@ -991,16 +1411,104 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1013,6 +1521,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "powerfmt"
@@ -1039,24 +1553,131 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratatui"
-version = "0.29.0"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
- "bitflags",
- "cassowary",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termina",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.1",
  "compact_str",
+ "critical-section",
+ "hashbrown 0.17.1",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum 0.28.0",
+ "thiserror 2.0.12",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
  "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.1",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
- "strum 0.26.3",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum 0.28.0",
+ "time",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1065,7 +1686,27 @@ version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1104,12 +1745,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustix"
-version = "0.38.44"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "bitflags",
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1129,41 +1779,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1174,7 +1865,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1191,19 +1882,32 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.8.0",
- "serde",
- "serde_derive",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
  "serde_json",
  "time",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1252,6 +1956,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,30 +2006,17 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 
 [[package]]
-name = "strum_macros"
-version = "0.26.4"
+name = "strum"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -1332,7 +2029,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1347,6 +2067,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,7 +2085,92 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.1",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.1",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1363,7 +2179,18 @@ version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1374,7 +2201,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1388,30 +2215,32 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.40"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.21"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aa485584182073ed57fd5004aa09c371f021325014694e432313345865fd04"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1426,6 +2255,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1453,7 +2297,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1507,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "sharded-slab",
  "thread_local",
@@ -1521,6 +2365,18 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
@@ -1536,20 +2392,14 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -1581,10 +2431,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "want"
@@ -1600,6 +2483,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1623,7 +2515,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -1645,7 +2537,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1657,6 +2549,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -1697,6 +2661,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,6 +2682,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1779,6 +2758,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,7 +2795,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -1831,7 +2816,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -1854,5 +2839,11 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,7 @@ dependencies = [
  "regex",
  "strum 0.27.1",
  "strum_macros 0.27.1",
+ "thiserror 2.0.12",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "crabd"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bollard",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crabd"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Sertan Canpolat <58915038+scnplt@users.noreply.github.com>"]
 license-file = "LICENSE.txt"
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 bollard = "0.18.1"
 color-eyre = "0.6.5"
-crossterm = { version = "0.28.1", features = ["event-stream"] }
+crossterm = { version = "0.29.0", features = ["event-stream"] }
 futures = "0.3.31"
-ratatui = "0.29.0"
+ratatui = "0.30.0"
 regex = "1.11.1"
 strum = "0.27.1"
 strum_macros = "0.27.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ ratatui = "0.30.0"
 regex = "1.11.1"
 strum = "0.27.1"
 strum_macros = "0.27.1"
+thiserror = "2.0"
 tokio = {version = "1.44.2", features = ["full"]}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ cargo run --release
 - Add customization options (themes, keybindings, etc.)
 - Improve error handling and user feedback
 - Add more advanced filtering and search features
-- Add tests and CI/CD pipeline
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ cargo run --release
 
 ## Contributing
 
-Contributions are welcome! Please open issues or pull requests on [GitHub](https://github.com/scnplt/crabd).
+Contributions are welcome! Please open issues or pull requests on [GitHub](https://github.com/scnplt/crabd) and read [CONTRIBUTING.md](./CONTRIBUTING.md) first for the branching model, commit conventions, and checks.
+
+All repository content — code, comments, documentation, commit messages, issues, and pull requests — must be written in English.
 
 ## License
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::docker::client::DockerClient;
+use crate::docker::client::{DockerApi, DockerClient};
 use crate::event::{AppEvent, Event, EventHandler};
 use crate::ui::container_info_block::{ContainerData, ContainerInfoBlock};
 use crate::ui::container_table::{ContainerTable, ContainerTableRow};
@@ -21,10 +21,10 @@ use ratatui::{
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, FromRepr};
 
-pub struct App {
+pub struct App<C: DockerApi> {
     running: bool,
     events: EventHandler,
-    docker_client: DockerClient,
+    docker_client: C,
     selected_tab: SelectedTab,
     container_table: ContainerTable,
     container_info: Option<Box<dyn ScrollableInfoBlock<Data = ContainerData>>>,
@@ -33,7 +33,7 @@ pub struct App {
     image_table: ImageTable,
 }
 
-impl App {
+impl App<DockerClient> {
     pub fn new() -> Result<Self> {
         Ok(Self {
             running: true,
@@ -46,6 +46,26 @@ impl App {
             network_table: NetworkTable::default(),
             image_table: ImageTable::default(),
         })
+    }
+}
+
+impl<C: DockerApi> App<C> {
+    /// Test-only constructor; builds an `App` from a caller-provided `DockerApi`
+    /// implementation, using the event handler's test constructor so no crossterm
+    /// reader task is spawned.
+    #[cfg(test)]
+    fn with_client(docker_client: C) -> Self {
+        Self {
+            running: true,
+            events: EventHandler::new_without_reader(),
+            docker_client,
+            selected_tab: SelectedTab::default(),
+            container_table: ContainerTable::default(),
+            container_info: None,
+            volume_table: VolumeTable::default(),
+            network_table: NetworkTable::default(),
+            image_table: ImageTable::default(),
+        }
     }
 
     pub async fn run(mut self, mut terminal: DefaultTerminal) -> Result<()> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use crate::docker::client::{DockerApi, DockerClient};
 use crate::docker::error::{DockerError, DockerResult};
-use crate::event::{AppEvent, Event, EventHandler};
+use crate::event::{AppEvent, DockerOutcome, Event, EventHandler, ResourceKind};
 use crate::ui::container_info_block::{ContainerData, ContainerInfoBlock};
 use crate::ui::container_table::{ContainerTable, ContainerTableRow};
 use crate::ui::image_table::{ImageTable, ImageTableRow};
@@ -19,6 +19,7 @@ use ratatui::{
     DefaultTerminal,
     crossterm::event::{KeyCode, KeyEvent, KeyModifiers},
 };
+use std::future::Future;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, FromRepr};
 
@@ -32,6 +33,19 @@ pub struct App<C: DockerApi> {
     volume_table: VolumeTable,
     network_table: NetworkTable,
     image_table: ImageTable,
+    pending: PendingRefreshes,
+    details_requested: bool,
+}
+
+/// Tracks in-flight list requests so `App` never has more than one outstanding
+/// refresh per resource kind at a time.
+#[derive(Default)]
+struct PendingRefreshes {
+    containers: bool,
+    volumes: bool,
+    networks: bool,
+    images: bool,
+    container_info: bool,
 }
 
 impl App<DockerClient> {
@@ -46,6 +60,8 @@ impl App<DockerClient> {
             volume_table: VolumeTable::default(),
             network_table: NetworkTable::default(),
             image_table: ImageTable::default(),
+            pending: PendingRefreshes::default(),
+            details_requested: false,
         })
     }
 }
@@ -66,11 +82,13 @@ impl<C: DockerApi> App<C> {
             volume_table: VolumeTable::default(),
             network_table: NetworkTable::default(),
             image_table: ImageTable::default(),
+            pending: PendingRefreshes::default(),
+            details_requested: false,
         }
     }
 
     pub async fn run(mut self, mut terminal: DefaultTerminal) -> Result<()> {
-        self.update_containers().await;
+        self.request_containers();
 
         while self.running {
             terminal.draw(|frame| self.draw(frame, frame.area()))?;
@@ -132,22 +150,26 @@ impl<C: DockerApi> App<C> {
                     self.events.send(event);
                 }
             }
+            Event::Docker(outcome) => self.apply_docker_outcome(outcome),
             Event::App(app_event) => match app_event {
                 AppEvent::Quit => self.quit(),
-                AppEvent::UpdateContainers => self.update_containers().await,
-                AppEvent::UpdateContainerInfo(id) => self.update_container_details(id).await,
-                AppEvent::RestartContainer(id) => self.restart_container(id).await,
-                AppEvent::StopContainer(id) => self.stop_container(id).await,
-                AppEvent::KillContainer(id) => self.kill_container(id).await,
-                AppEvent::RemoveContainer(id) => self.remove_container(id).await,
-                AppEvent::GoToContainerDetails(id) => self.go_to_container_info(id).await,
-                AppEvent::UpdateVolumes => self.update_volumes().await,
-                AppEvent::RemoveVolume(name, force) => self.remove_volume(name, force).await,
-                AppEvent::UpdateNetworks => self.update_networks().await,
-                AppEvent::RemoveNetwork(name) => self.remove_network(name).await,
-                AppEvent::UpdateImages => self.update_images().await,
-                AppEvent::RemoveImage(id, force) => self.remove_image(id, force).await,
-                AppEvent::Back => self.container_info = None,
+                AppEvent::UpdateContainers => self.request_containers(),
+                AppEvent::UpdateContainerInfo(id) => self.request_container_details(id),
+                AppEvent::RestartContainer(id) => self.request_restart_container(id),
+                AppEvent::StopContainer(id) => self.request_stop_container(id),
+                AppEvent::KillContainer(id) => self.request_kill_container(id),
+                AppEvent::RemoveContainer(id) => self.request_remove_container(id),
+                AppEvent::GoToContainerDetails(id) => self.request_container_details_open(id),
+                AppEvent::UpdateVolumes => self.request_volumes(),
+                AppEvent::RemoveVolume(name, force) => self.request_remove_volume(name, force),
+                AppEvent::UpdateNetworks => self.request_networks(),
+                AppEvent::RemoveNetwork(name) => self.request_remove_network(name),
+                AppEvent::UpdateImages => self.request_images(),
+                AppEvent::RemoveImage(id, force) => self.request_remove_image(id, force),
+                AppEvent::Back => {
+                    self.details_requested = false;
+                    self.container_info = None;
+                }
             },
         }
         Ok(())
@@ -190,14 +212,6 @@ impl<C: DockerApi> App<C> {
         self.selected_tab = self.selected_tab.previous()
     }
 
-    async fn go_to_container_info(&mut self, container_id: String) {
-        if let Some(data) = self.get_container_data(container_id).await {
-            let mut container_info_block = ContainerInfoBlock::default();
-            container_info_block.update_data(data);
-            self.container_info = Some(Box::new(container_info_block));
-        }
-    }
-
     fn tick(&mut self) -> Result<Option<AppEvent>> {
         if let Some(info) = self.container_info.as_mut() {
             return info.tick();
@@ -237,88 +251,240 @@ impl<C: DockerApi> App<C> {
         }
     }
 
-    async fn get_container_data(&mut self, container_id: String) -> Option<ContainerData> {
-        let result = self.docker_client.inspect_container(&container_id).await;
-        self.ok_or_report(SelectedTab::Containers, result)
-            .map(ContainerData::from)
+    /// Maps a Docker outcome's resource kind back to the tab that owns it.
+    fn tab_of(resource: ResourceKind) -> SelectedTab {
+        match resource {
+            ResourceKind::Containers => SelectedTab::Containers,
+            ResourceKind::Volumes => SelectedTab::Volumes,
+            ResourceKind::Networks => SelectedTab::Networks,
+            ResourceKind::Images => SelectedTab::Images,
+        }
     }
 
-    async fn update_container_details(&mut self, container_id: String) {
-        let Some(data) = self.get_container_data(container_id).await else {
+    fn begin_action(&mut self, tab: SelectedTab) {
+        match tab {
+            SelectedTab::Containers => self.container_table.begin_pending_op(),
+            SelectedTab::Volumes => self.volume_table.begin_pending_op(),
+            SelectedTab::Networks => self.network_table.begin_pending_op(),
+            SelectedTab::Images => self.image_table.begin_pending_op(),
+        }
+    }
+
+    fn end_action(&mut self, tab: SelectedTab) {
+        match tab {
+            SelectedTab::Containers => self.container_table.end_pending_op(),
+            SelectedTab::Volumes => self.volume_table.end_pending_op(),
+            SelectedTab::Networks => self.network_table.end_pending_op(),
+            SelectedTab::Images => self.image_table.end_pending_op(),
+        }
+    }
+
+    /// Runs a Docker operation off the event loop; its outcome comes back as `Event::Docker`.
+    fn spawn_docker<F, Fut>(&self, op: F)
+    where
+        F: FnOnce(C) -> Fut + Send + 'static,
+        Fut: Future<Output = DockerOutcome> + Send + 'static,
+    {
+        let client = self.docker_client.clone();
+        let sender = self.events.sender();
+        tokio::spawn(async move {
+            let _ = sender.send(Event::Docker(op(client).await));
+        });
+    }
+
+    fn request_containers(&mut self) {
+        if self.pending.containers {
             return;
-        };
-        if let Some(info_block) = self.container_info.as_mut() {
-            info_block.update_data(data);
         }
+        self.pending.containers = true;
+        self.spawn_docker(
+            |c| async move { DockerOutcome::ContainersListed(c.list_containers().await) },
+        );
     }
 
-    async fn restart_container(&mut self, container_id: String) {
-        let result = self.docker_client.restart_container(&container_id).await;
-        self.ok_or_report(SelectedTab::Containers, result);
-    }
-
-    async fn stop_container(&mut self, container_id: String) {
-        let result = self.docker_client.stop_container(&container_id).await;
-        self.ok_or_report(SelectedTab::Containers, result);
-    }
-
-    async fn kill_container(&mut self, container_id: String) {
-        let result = self.docker_client.kill_container(&container_id).await;
-        self.ok_or_report(SelectedTab::Containers, result);
-    }
-
-    async fn remove_container(&mut self, container_id: String) {
-        let result = self.docker_client.remove_container(&container_id).await;
-        self.ok_or_report(SelectedTab::Containers, result);
-    }
-
-    async fn update_containers(&mut self) {
-        let result = self.docker_client.list_containers().await;
-        if let Some(result) = self.ok_or_report(SelectedTab::Containers, result) {
-            let containers = ContainerTableRow::from_list(result);
-            self.container_table.update_with_items(containers);
+    fn request_volumes(&mut self) {
+        if self.pending.volumes {
+            return;
         }
+        self.pending.volumes = true;
+        self.spawn_docker(|c| async move { DockerOutcome::VolumesListed(c.list_volumes().await) });
     }
 
-    async fn update_volumes(&mut self) {
-        let result = self.docker_client.list_volumes().await;
-        if let Some(response) = self.ok_or_report(SelectedTab::Volumes, result)
-            && let Some(volumes) = response.volumes
-        {
-            let volumes = VolumeTableRow::from_list(volumes);
-            self.volume_table.update_with_items(volumes);
+    fn request_networks(&mut self) {
+        if self.pending.networks {
+            return;
         }
+        self.pending.networks = true;
+        self.spawn_docker(
+            |c| async move { DockerOutcome::NetworksListed(c.list_networks().await) },
+        );
     }
 
-    async fn update_networks(&mut self) {
-        let result = self.docker_client.list_networks().await;
-        if let Some(result) = self.ok_or_report(SelectedTab::Networks, result) {
-            let networks = NetworkTableRow::from_list(result);
-            self.network_table.update_with_items(networks);
+    fn request_images(&mut self) {
+        if self.pending.images {
+            return;
         }
+        self.pending.images = true;
+        self.spawn_docker(|c| async move { DockerOutcome::ImagesListed(c.list_images().await) });
     }
 
-    async fn update_images(&mut self) {
-        let result = self.docker_client.list_images().await;
-        if let Some(result) = self.ok_or_report(SelectedTab::Images, result) {
-            let images = ImageTableRow::from_list(result);
-            self.image_table.update_with_items(images);
+    fn request_container_details(&mut self, id: String) {
+        if self.pending.container_info {
+            return;
         }
+        self.pending.container_info = true;
+        self.spawn_docker(|c| async move {
+            let result = c.inspect_container(&id).await.map(Box::new);
+            DockerOutcome::ContainerInspected {
+                open_details: false,
+                result,
+            }
+        });
     }
 
-    async fn remove_volume(&mut self, name: String, force: bool) {
-        let result = self.docker_client.remove_volume(&name, force).await;
-        self.ok_or_report(SelectedTab::Volumes, result);
+    fn request_container_details_open(&mut self, id: String) {
+        self.details_requested = true;
+        self.spawn_docker(|c| async move {
+            let result = c.inspect_container(&id).await.map(Box::new);
+            DockerOutcome::ContainerInspected {
+                open_details: true,
+                result,
+            }
+        });
     }
 
-    async fn remove_network(&mut self, name: String) {
-        let result = self.docker_client.remove_network(&name).await;
-        self.ok_or_report(SelectedTab::Networks, result);
+    fn request_restart_container(&mut self, id: String) {
+        self.begin_action(SelectedTab::Containers);
+        self.spawn_docker(|c| async move {
+            DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Containers,
+                result: c.restart_container(&id).await,
+            }
+        });
     }
 
-    async fn remove_image(&mut self, id: String, force: bool) {
-        let result = self.docker_client.remove_image(&id, force).await;
-        self.ok_or_report(SelectedTab::Images, result);
+    fn request_stop_container(&mut self, id: String) {
+        self.begin_action(SelectedTab::Containers);
+        self.spawn_docker(|c| async move {
+            DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Containers,
+                result: c.stop_container(&id).await,
+            }
+        });
+    }
+
+    fn request_kill_container(&mut self, id: String) {
+        self.begin_action(SelectedTab::Containers);
+        self.spawn_docker(|c| async move {
+            DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Containers,
+                result: c.kill_container(&id).await,
+            }
+        });
+    }
+
+    fn request_remove_container(&mut self, id: String) {
+        self.begin_action(SelectedTab::Containers);
+        self.spawn_docker(|c| async move {
+            DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Containers,
+                result: c.remove_container(&id).await,
+            }
+        });
+    }
+
+    fn request_remove_volume(&mut self, name: String, force: bool) {
+        self.begin_action(SelectedTab::Volumes);
+        self.spawn_docker(move |c| async move {
+            DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Volumes,
+                result: c.remove_volume(&name, force).await,
+            }
+        });
+    }
+
+    fn request_remove_network(&mut self, name: String) {
+        self.begin_action(SelectedTab::Networks);
+        self.spawn_docker(|c| async move {
+            DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Networks,
+                result: c.remove_network(&name).await,
+            }
+        });
+    }
+
+    fn request_remove_image(&mut self, id: String, force: bool) {
+        self.begin_action(SelectedTab::Images);
+        self.spawn_docker(move |c| async move {
+            DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Images,
+                result: c.remove_image(&id, force).await,
+            }
+        });
+    }
+
+    fn apply_docker_outcome(&mut self, outcome: DockerOutcome) {
+        match outcome {
+            DockerOutcome::ContainersListed(result) => {
+                self.pending.containers = false;
+                if let Some(list) = self.ok_or_report(SelectedTab::Containers, result) {
+                    self.container_table
+                        .update_with_items(ContainerTableRow::from_list(list));
+                }
+            }
+            DockerOutcome::VolumesListed(result) => {
+                self.pending.volumes = false;
+                if let Some(response) = self.ok_or_report(SelectedTab::Volumes, result)
+                    && let Some(volumes) = response.volumes
+                {
+                    self.volume_table
+                        .update_with_items(VolumeTableRow::from_list(volumes));
+                }
+            }
+            DockerOutcome::NetworksListed(result) => {
+                self.pending.networks = false;
+                if let Some(list) = self.ok_or_report(SelectedTab::Networks, result) {
+                    self.network_table
+                        .update_with_items(NetworkTableRow::from_list(list));
+                }
+            }
+            DockerOutcome::ImagesListed(result) => {
+                self.pending.images = false;
+                if let Some(list) = self.ok_or_report(SelectedTab::Images, result) {
+                    self.image_table
+                        .update_with_items(ImageTableRow::from_list(list));
+                }
+            }
+            DockerOutcome::ContainerInspected {
+                open_details,
+                result,
+            } => {
+                if !open_details {
+                    self.pending.container_info = false;
+                }
+                let Some(data) = self
+                    .ok_or_report(SelectedTab::Containers, result)
+                    .map(|r| ContainerData::from(*r))
+                else {
+                    return;
+                };
+                if open_details {
+                    if !self.details_requested {
+                        return;
+                    }
+                    let mut container_info_block = ContainerInfoBlock::default();
+                    container_info_block.update_data(data);
+                    self.container_info = Some(Box::new(container_info_block));
+                } else if let Some(block) = self.container_info.as_mut() {
+                    block.update_data(data);
+                }
+            }
+            DockerOutcome::ActionCompleted { resource, result } => {
+                let tab = Self::tab_of(resource);
+                self.end_action(tab);
+                self.ok_or_report(tab, result);
+            }
+        }
     }
 }
 
@@ -372,9 +538,9 @@ mod tests {
         VolumeListResponse,
     };
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
 
-    #[derive(Default)]
+    #[derive(Clone, Default)]
     struct MockDockerClient {
         containers: Vec<ContainerSummary>,
         volumes: Vec<Volume>,
@@ -382,7 +548,7 @@ mod tests {
         images: Vec<ImageSummary>,
         inspect: Option<ContainerInspectResponse>,
         fail_with: Option<DockerError>,
-        calls: Mutex<Vec<String>>,
+        calls: Arc<Mutex<Vec<String>>>,
     }
 
     impl MockDockerClient {
@@ -530,185 +696,180 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn update_containers_populates_table() {
-        let mock = MockDockerClient {
-            containers: vec![container_summary("a"), container_summary("b")],
-            ..Default::default()
-        };
+    #[test]
+    fn update_containers_populates_table() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.update_containers().await;
+        app.apply_docker_outcome(DockerOutcome::ContainersListed(Ok(vec![
+            container_summary("a"),
+            container_summary("b"),
+        ])));
 
         assert_eq!(app.container_table.table_info().items.len(), 2);
     }
 
-    #[tokio::test]
-    async fn update_volumes_populates_table() {
-        let mock = MockDockerClient {
-            volumes: vec![volume("a"), volume("b")],
-            ..Default::default()
-        };
+    #[test]
+    fn update_volumes_populates_table() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.update_volumes().await;
+        app.apply_docker_outcome(DockerOutcome::VolumesListed(Ok(VolumeListResponse {
+            volumes: Some(vec![volume("a"), volume("b")]),
+            ..Default::default()
+        })));
 
         assert_eq!(app.volume_table.table_info().items.len(), 2);
     }
 
-    #[tokio::test]
-    async fn update_networks_populates_table() {
-        let mock = MockDockerClient {
-            networks: vec![network("111111111111", "a"), network("222222222222", "b")],
-            ..Default::default()
-        };
+    #[test]
+    fn update_networks_populates_table() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.update_networks().await;
+        app.apply_docker_outcome(DockerOutcome::NetworksListed(Ok(vec![
+            network("111111111111", "a"),
+            network("222222222222", "b"),
+        ])));
 
         assert_eq!(app.network_table.table_info().items.len(), 2);
     }
 
-    #[tokio::test]
-    async fn update_images_populates_table() {
-        let mock = MockDockerClient {
-            images: vec![
-                image("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"),
-                image("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abce"),
-            ],
-            ..Default::default()
-        };
+    #[test]
+    fn update_images_populates_table() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.update_images().await;
+        app.apply_docker_outcome(DockerOutcome::ImagesListed(Ok(vec![
+            image("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"),
+            image("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abce"),
+        ])));
 
         assert_eq!(app.image_table.table_info().items.len(), 2);
     }
 
-    #[tokio::test]
-    async fn restart_container_error_is_shown_in_footer() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::Conflict {
-                message: "daemon says no".to_string(),
-            }),
-            ..Default::default()
-        };
+    #[test]
+    fn restart_container_error_is_shown_in_footer() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.restart_container("container-id".to_string()).await;
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Containers,
+            result: Err(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+        });
 
         let err = app.container_table.table_info().err.clone().unwrap();
         assert_eq!(err, "[ERR] Conflict: daemon says no");
     }
 
-    #[tokio::test]
-    async fn stop_container_error_is_shown_in_footer() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::Conflict {
-                message: "daemon says no".to_string(),
-            }),
-            ..Default::default()
-        };
+    #[test]
+    fn stop_container_error_is_shown_in_footer() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.stop_container("container-id".to_string()).await;
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Containers,
+            result: Err(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+        });
 
         let err = app.container_table.table_info().err.clone().unwrap();
         assert_eq!(err, "[ERR] Conflict: daemon says no");
     }
 
-    #[tokio::test]
-    async fn kill_container_error_is_shown_in_footer() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::Conflict {
-                message: "daemon says no".to_string(),
-            }),
-            ..Default::default()
-        };
+    #[test]
+    fn kill_container_error_is_shown_in_footer() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.kill_container("container-id".to_string()).await;
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Containers,
+            result: Err(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+        });
 
         let err = app.container_table.table_info().err.clone().unwrap();
         assert_eq!(err, "[ERR] Conflict: daemon says no");
     }
 
-    #[tokio::test]
-    async fn remove_volume_error_is_shown_in_footer() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::Conflict {
+    #[test]
+    fn remove_volume_error_is_shown_in_footer() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Volumes,
+            result: Err(DockerError::Conflict {
                 message: "volume is in use".to_string(),
             }),
-            ..Default::default()
-        };
-        let mut app = App::with_client(mock);
-
-        app.remove_volume("volume-name".to_string(), false).await;
+        });
 
         let err = app.volume_table.table_info().err.clone().unwrap();
         assert_eq!(err, "[ERR] Conflict: volume is in use");
     }
 
-    #[tokio::test]
-    async fn remove_network_error_is_shown_in_footer() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::Conflict {
-                message: "daemon says no".to_string(),
-            }),
-            ..Default::default()
-        };
+    #[test]
+    fn remove_network_error_is_shown_in_footer() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.remove_network("network-name".to_string()).await;
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Networks,
+            result: Err(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+        });
 
         let err = app.network_table.table_info().err.clone().unwrap();
         assert_eq!(err, "[ERR] Conflict: daemon says no");
     }
 
-    #[tokio::test]
-    async fn remove_image_error_is_shown_in_footer() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::Conflict {
-                message: "daemon says no".to_string(),
-            }),
-            ..Default::default()
-        };
+    #[test]
+    fn remove_image_error_is_shown_in_footer() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.remove_image("image-id".to_string(), false).await;
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Images,
+            result: Err(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+        });
 
         let err = app.image_table.table_info().err.clone().unwrap();
         assert_eq!(err, "[ERR] Conflict: daemon says no");
     }
 
-    #[tokio::test]
-    async fn list_failure_shows_error_on_owning_tab() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::DaemonUnreachable {
-                details: "connection refused".to_string(),
-            }),
-            ..Default::default()
-        };
+    #[test]
+    fn list_failure_shows_error_on_owning_tab() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
         assert_eq!(app.selected_tab as usize, SelectedTab::Containers as usize);
 
-        app.update_images().await;
+        app.apply_docker_outcome(DockerOutcome::ImagesListed(Err(
+            DockerError::DaemonUnreachable {
+                details: "connection refused".to_string(),
+            },
+        )));
 
         assert!(app.image_table.table_info().err.is_some());
         assert!(app.container_table.table_info().err.is_none());
     }
 
-    #[tokio::test]
-    async fn list_failure_keeps_previous_items() {
-        let mock = MockDockerClient {
-            fail_with: Some(DockerError::DaemonUnreachable {
-                details: "connection refused".to_string(),
-            }),
-            ..Default::default()
-        };
+    #[test]
+    fn list_failure_keeps_previous_items() {
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.update_containers().await;
+        app.apply_docker_outcome(DockerOutcome::ContainersListed(Err(
+            DockerError::DaemonUnreachable {
+                details: "connection refused".to_string(),
+            },
+        )));
 
         assert_eq!(app.container_table.table_info().items.len(), 0);
         assert!(app.container_table.table_info().err.is_some());
@@ -716,16 +877,17 @@ mod tests {
 
     #[tokio::test]
     async fn go_to_container_info_opens_and_back_closes() {
-        let mock = MockDockerClient {
-            inspect: Some(ContainerInspectResponse {
-                id: Some("container-id".to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.go_to_container_info("container-id".to_string()).await;
+        app.request_container_details_open("container-id".to_string());
+        app.apply_docker_outcome(DockerOutcome::ContainerInspected {
+            open_details: true,
+            result: Ok(Box::new(ContainerInspectResponse {
+                id: Some("container-id".to_string()),
+                ..Default::default()
+            })),
+        });
         assert!(app.container_info.is_some());
 
         let event = app.handle_key_event(KeyEvent::from(KeyCode::Esc)).unwrap();
@@ -734,21 +896,137 @@ mod tests {
 
     #[tokio::test]
     async fn key_events_route_to_info_block_when_open() {
-        let mock = MockDockerClient {
-            inspect: Some(ContainerInspectResponse {
-                id: Some("container-id".to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
+        let mock = MockDockerClient::default();
         let mut app = App::with_client(mock);
 
-        app.go_to_container_info("container-id".to_string()).await;
+        app.request_container_details_open("container-id".to_string());
+        app.apply_docker_outcome(DockerOutcome::ContainerInspected {
+            open_details: true,
+            result: Ok(Box::new(ContainerInspectResponse {
+                id: Some("container-id".to_string()),
+                ..Default::default()
+            })),
+        });
 
         let tab_before = app.selected_tab as usize;
         app.handle_key_event(KeyEvent::from(KeyCode::Char('t')))
             .unwrap();
         assert_eq!(app.selected_tab as usize, tab_before);
+    }
+
+    #[tokio::test]
+    async fn request_containers_dispatches_to_the_client() {
+        let mock = MockDockerClient::default();
+        let calls = mock.calls.clone();
+        let mut app = App::with_client(mock);
+
+        app.request_containers();
+
+        let event = app.events.next().await.unwrap();
+        assert!(matches!(
+            event,
+            Event::Docker(DockerOutcome::ContainersListed(Ok(_)))
+        ));
+        assert_eq!(*calls.lock().unwrap(), vec!["list_containers".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn duplicate_refresh_is_dropped_while_one_is_in_flight() {
+        let mock = MockDockerClient::default();
+        let calls = mock.calls.clone();
+        let mut app = App::with_client(mock);
+
+        app.request_containers();
+        app.request_containers();
+
+        let _ = app.events.next().await.unwrap();
+        assert!(app.events.try_next().is_none());
+        assert_eq!(calls.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn refresh_is_allowed_again_after_the_outcome_is_applied() {
+        let mock = MockDockerClient::default();
+        let calls = mock.calls.clone();
+        let mut app = App::with_client(mock);
+
+        app.request_containers();
+        let event = app.events.next().await.unwrap();
+        if let Event::Docker(outcome) = event {
+            app.apply_docker_outcome(outcome);
+        }
+
+        app.request_containers();
+        let _ = app.events.next().await.unwrap();
+
+        assert_eq!(calls.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn actions_are_not_deduplicated() {
+        let mock = MockDockerClient::default();
+        let calls = mock.calls.clone();
+        let mut app = App::with_client(mock);
+
+        app.request_stop_container("container-a".to_string());
+        app.request_stop_container("container-b".to_string());
+
+        let _ = app.events.next().await.unwrap();
+        let _ = app.events.next().await.unwrap();
+
+        assert_eq!(calls.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn action_marks_and_clears_the_pending_indicator() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        app.request_stop_container("container-id".to_string());
+        assert_eq!(app.container_table.table_info().pending_ops, 1);
+
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Containers,
+            result: Ok(()),
+        });
+        assert_eq!(app.container_table.table_info().pending_ops, 0);
+    }
+
+    #[tokio::test]
+    async fn back_prevents_a_late_details_open() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        app.request_container_details_open("container-id".to_string());
+        app.details_requested = false;
+        app.container_info = None;
+
+        app.apply_docker_outcome(DockerOutcome::ContainerInspected {
+            open_details: true,
+            result: Ok(Box::new(ContainerInspectResponse {
+                id: Some("container-id".to_string()),
+                ..Default::default()
+            })),
+        });
+
+        assert!(app.container_info.is_none());
+    }
+
+    #[tokio::test]
+    async fn stop_container_failure_reaches_the_footer_through_the_channel() {
+        let mock = MockDockerClient {
+            fail_with: Some(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.request_stop_container("container-id".to_string());
+        app.process_next_event().await.unwrap();
+
+        let err = app.container_table.table_info().err.clone().unwrap();
+        assert_eq!(err, "[ERR] Conflict: daemon says no");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use crate::docker::client::{DockerApi, DockerClient};
+use crate::docker::error::{DockerError, DockerResult};
 use crate::event::{AppEvent, Event, EventHandler};
 use crate::ui::container_info_block::{ContainerData, ContainerInfoBlock};
 use crate::ui::container_table::{ContainerTable, ContainerTableRow};
@@ -69,7 +70,7 @@ impl<C: DockerApi> App<C> {
     }
 
     pub async fn run(mut self, mut terminal: DefaultTerminal) -> Result<()> {
-        self.update_containers().await?;
+        self.update_containers().await;
 
         while self.running {
             terminal.draw(|frame| self.draw(frame, frame.area()))?;
@@ -133,19 +134,19 @@ impl<C: DockerApi> App<C> {
             }
             Event::App(app_event) => match app_event {
                 AppEvent::Quit => self.quit(),
-                AppEvent::UpdateContainers => self.update_containers().await?,
-                AppEvent::UpdateContainerInfo(id) => self.update_container_details(id).await?,
-                AppEvent::RestartContainer(id) => self.restart_container(id).await?,
-                AppEvent::StopContainer(id) => self.docker_client.stop_container(&id).await?,
-                AppEvent::KillContainer(id) => self.docker_client.kill_container(&id).await?,
-                AppEvent::RemoveContainer(id) => self.remove_container(id).await?,
-                AppEvent::GoToContainerDetails(id) => self.go_to_container_info(id).await?,
-                AppEvent::UpdateVolumes => self.update_volumes().await?,
-                AppEvent::RemoveVolume(name, force) => self.remove_volume(name, force).await?,
-                AppEvent::UpdateNetworks => self.update_networks().await?,
-                AppEvent::RemoveNetwork(name) => self.remove_network(name).await?,
-                AppEvent::UpdateImages => self.update_images().await?,
-                AppEvent::RemoveImage(id, force) => self.remove_image(id, force).await?,
+                AppEvent::UpdateContainers => self.update_containers().await,
+                AppEvent::UpdateContainerInfo(id) => self.update_container_details(id).await,
+                AppEvent::RestartContainer(id) => self.restart_container(id).await,
+                AppEvent::StopContainer(id) => self.stop_container(id).await,
+                AppEvent::KillContainer(id) => self.kill_container(id).await,
+                AppEvent::RemoveContainer(id) => self.remove_container(id).await,
+                AppEvent::GoToContainerDetails(id) => self.go_to_container_info(id).await,
+                AppEvent::UpdateVolumes => self.update_volumes().await,
+                AppEvent::RemoveVolume(name, force) => self.remove_volume(name, force).await,
+                AppEvent::UpdateNetworks => self.update_networks().await,
+                AppEvent::RemoveNetwork(name) => self.remove_network(name).await,
+                AppEvent::UpdateImages => self.update_images().await,
+                AppEvent::RemoveImage(id, force) => self.remove_image(id, force).await,
                 AppEvent::Back => self.container_info = None,
             },
         }
@@ -189,13 +190,12 @@ impl<C: DockerApi> App<C> {
         self.selected_tab = self.selected_tab.previous()
     }
 
-    async fn go_to_container_info(&mut self, container_id: String) -> Result<()> {
+    async fn go_to_container_info(&mut self, container_id: String) {
         if let Some(data) = self.get_container_data(container_id).await {
             let mut container_info_block = ContainerInfoBlock::default();
             container_info_block.update_data(data);
             self.container_info = Some(Box::new(container_info_block));
         }
-        Ok(())
     }
 
     fn tick(&mut self) -> Result<Option<AppEvent>> {
@@ -217,87 +217,108 @@ impl<C: DockerApi> App<C> {
         self.running = false;
     }
 
-    async fn get_container_data(&self, container_id: String) -> Option<ContainerData> {
-        if let Ok(data) = self.docker_client.inspect_container(&container_id).await {
-            return Some(ContainerData::from(data));
+    fn report_err(&mut self, tab: SelectedTab, err: &DockerError) {
+        match tab {
+            SelectedTab::Containers => self.container_table.show_err(err),
+            SelectedTab::Volumes => self.volume_table.show_err(err),
+            SelectedTab::Networks => self.network_table.show_err(err),
+            SelectedTab::Images => self.image_table.show_err(err),
         }
-        None
     }
 
-    async fn update_container_details(&mut self, container_id: String) -> Result<()> {
-        if let Some(data) = self.get_container_data(container_id).await
-            && let Some(info_block) = self.container_info.as_mut()
-        {
+    /// Unwraps a Docker result, reporting failures into `tab`'s footer.
+    fn ok_or_report<T>(&mut self, tab: SelectedTab, result: DockerResult<T>) -> Option<T> {
+        match result {
+            Ok(value) => Some(value),
+            Err(err) => {
+                self.report_err(tab, &err);
+                None
+            }
+        }
+    }
+
+    async fn get_container_data(&mut self, container_id: String) -> Option<ContainerData> {
+        let result = self.docker_client.inspect_container(&container_id).await;
+        self.ok_or_report(SelectedTab::Containers, result)
+            .map(ContainerData::from)
+    }
+
+    async fn update_container_details(&mut self, container_id: String) {
+        let Some(data) = self.get_container_data(container_id).await else {
+            return;
+        };
+        if let Some(info_block) = self.container_info.as_mut() {
             info_block.update_data(data);
         }
-        Ok(())
     }
 
-    async fn restart_container(&mut self, container_id: String) -> Result<()> {
-        if let Err(e) = self.docker_client.restart_container(&container_id).await {
-            self.container_table.show_err(e.to_string());
-        }
-        Ok(())
+    async fn restart_container(&mut self, container_id: String) {
+        let result = self.docker_client.restart_container(&container_id).await;
+        self.ok_or_report(SelectedTab::Containers, result);
     }
 
-    async fn remove_container(&mut self, container_id: String) -> Result<()> {
-        if let Err(e) = self.docker_client.remove_container(&container_id).await {
-            self.container_table.show_err(e.to_string());
-        }
-        Ok(())
+    async fn stop_container(&mut self, container_id: String) {
+        let result = self.docker_client.stop_container(&container_id).await;
+        self.ok_or_report(SelectedTab::Containers, result);
     }
 
-    async fn update_containers(&mut self) -> Result<()> {
-        if let Ok(result) = self.docker_client.list_containers().await {
+    async fn kill_container(&mut self, container_id: String) {
+        let result = self.docker_client.kill_container(&container_id).await;
+        self.ok_or_report(SelectedTab::Containers, result);
+    }
+
+    async fn remove_container(&mut self, container_id: String) {
+        let result = self.docker_client.remove_container(&container_id).await;
+        self.ok_or_report(SelectedTab::Containers, result);
+    }
+
+    async fn update_containers(&mut self) {
+        let result = self.docker_client.list_containers().await;
+        if let Some(result) = self.ok_or_report(SelectedTab::Containers, result) {
             let containers = ContainerTableRow::from_list(result);
             self.container_table.update_with_items(containers);
         }
-        Ok(())
     }
 
-    async fn update_volumes(&mut self) -> Result<()> {
-        if let Some(result) = self.docker_client.list_volumes().await?.volumes {
-            let volumes = VolumeTableRow::from_list(result);
+    async fn update_volumes(&mut self) {
+        let result = self.docker_client.list_volumes().await;
+        if let Some(response) = self.ok_or_report(SelectedTab::Volumes, result)
+            && let Some(volumes) = response.volumes
+        {
+            let volumes = VolumeTableRow::from_list(volumes);
             self.volume_table.update_with_items(volumes);
         }
-        Ok(())
     }
 
-    async fn update_networks(&mut self) -> Result<()> {
-        if let Ok(result) = self.docker_client.list_networks().await {
+    async fn update_networks(&mut self) {
+        let result = self.docker_client.list_networks().await;
+        if let Some(result) = self.ok_or_report(SelectedTab::Networks, result) {
             let networks = NetworkTableRow::from_list(result);
             self.network_table.update_with_items(networks);
         }
-        Ok(())
     }
 
-    async fn update_images(&mut self) -> Result<()> {
-        if let Ok(result) = self.docker_client.list_images().await {
+    async fn update_images(&mut self) {
+        let result = self.docker_client.list_images().await;
+        if let Some(result) = self.ok_or_report(SelectedTab::Images, result) {
             let images = ImageTableRow::from_list(result);
             self.image_table.update_with_items(images);
         }
-        Ok(())
     }
 
-    async fn remove_volume(&mut self, name: String, force: bool) -> Result<()> {
-        if let Err(e) = self.docker_client.remove_volume(&name, force).await {
-            self.volume_table.show_err(e.to_string());
-        }
-        Ok(())
+    async fn remove_volume(&mut self, name: String, force: bool) {
+        let result = self.docker_client.remove_volume(&name, force).await;
+        self.ok_or_report(SelectedTab::Volumes, result);
     }
 
-    async fn remove_network(&mut self, name: String) -> Result<()> {
-        if let Err(e) = self.docker_client.remove_network(&name).await {
-            self.network_table.show_err(e.to_string());
-        }
-        Ok(())
+    async fn remove_network(&mut self, name: String) {
+        let result = self.docker_client.remove_network(&name).await;
+        self.ok_or_report(SelectedTab::Networks, result);
     }
 
-    async fn remove_image(&mut self, id: String, force: bool) -> Result<()> {
-        if let Err(e) = self.docker_client.remove_image(&id, force).await {
-            self.image_table.show_err(e.to_string());
-        }
-        Ok(())
+    async fn remove_image(&mut self, id: String, force: bool) {
+        let result = self.docker_client.remove_image(&id, force).await;
+        self.ok_or_report(SelectedTab::Images, result);
     }
 }
 
@@ -350,7 +371,6 @@ mod tests {
         ContainerInspectResponse, ContainerSummary, ImageSummary, Network, Volume,
         VolumeListResponse,
     };
-    use color_eyre::eyre::eyre;
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use std::sync::Mutex;
 
@@ -361,7 +381,7 @@ mod tests {
         networks: Vec<Network>,
         images: Vec<ImageSummary>,
         inspect: Option<ContainerInspectResponse>,
-        fail_with: Option<String>,
+        fail_with: Option<DockerError>,
         calls: Mutex<Vec<String>>,
     }
 
@@ -372,88 +392,106 @@ mod tests {
     }
 
     impl DockerApi for MockDockerClient {
-        async fn list_containers(&self) -> Result<Vec<ContainerSummary>> {
+        async fn list_containers(&self) -> DockerResult<Vec<ContainerSummary>> {
             self.record("list_containers");
+            if let Some(e) = &self.fail_with {
+                return Err(e.clone());
+            }
             Ok(self.containers.clone())
         }
 
-        async fn stop_container(&self, container_id: &str) -> Result<()> {
+        async fn stop_container(&self, container_id: &str) -> DockerResult<()> {
             self.record(format!("stop_container:{container_id}"));
             match &self.fail_with {
-                Some(msg) => Err(eyre!(msg.clone())),
+                Some(e) => Err(e.clone()),
                 None => Ok(()),
             }
         }
 
-        async fn restart_container(&self, container_id: &str) -> Result<()> {
+        async fn restart_container(&self, container_id: &str) -> DockerResult<()> {
             self.record(format!("restart_container:{container_id}"));
             match &self.fail_with {
-                Some(msg) => Err(eyre!(msg.clone())),
+                Some(e) => Err(e.clone()),
                 None => Ok(()),
             }
         }
 
-        async fn kill_container(&self, container_id: &str) -> Result<()> {
+        async fn kill_container(&self, container_id: &str) -> DockerResult<()> {
             self.record(format!("kill_container:{container_id}"));
             match &self.fail_with {
-                Some(msg) => Err(eyre!(msg.clone())),
+                Some(e) => Err(e.clone()),
                 None => Ok(()),
             }
         }
 
-        async fn remove_container(&self, container_id: &str) -> Result<()> {
+        async fn remove_container(&self, container_id: &str) -> DockerResult<()> {
             self.record(format!("remove_container:{container_id}"));
             match &self.fail_with {
-                Some(msg) => Err(eyre!(msg.clone())),
+                Some(e) => Err(e.clone()),
                 None => Ok(()),
             }
         }
 
-        async fn inspect_container(&self, container_id: &str) -> Result<ContainerInspectResponse> {
+        async fn inspect_container(
+            &self,
+            container_id: &str,
+        ) -> DockerResult<ContainerInspectResponse> {
             self.record(format!("inspect_container:{container_id}"));
-            self.inspect
-                .clone()
-                .ok_or_else(|| eyre!("no inspect data configured"))
+            if let Some(e) = &self.fail_with {
+                return Err(e.clone());
+            }
+            self.inspect.clone().ok_or_else(|| DockerError::Other {
+                message: "no inspect data configured".to_string(),
+            })
         }
 
-        async fn list_volumes(&self) -> Result<VolumeListResponse> {
+        async fn list_volumes(&self) -> DockerResult<VolumeListResponse> {
             self.record("list_volumes");
+            if let Some(e) = &self.fail_with {
+                return Err(e.clone());
+            }
             Ok(VolumeListResponse {
                 volumes: Some(self.volumes.clone()),
                 ..Default::default()
             })
         }
 
-        async fn remove_volume(&self, name: &str, force: bool) -> Result<()> {
+        async fn remove_volume(&self, name: &str, force: bool) -> DockerResult<()> {
             self.record(format!("remove_volume:{name}:{force}"));
             match &self.fail_with {
-                Some(msg) => Err(eyre!(msg.clone())),
+                Some(e) => Err(e.clone()),
                 None => Ok(()),
             }
         }
 
-        async fn list_networks(&self) -> Result<Vec<Network>> {
+        async fn list_networks(&self) -> DockerResult<Vec<Network>> {
             self.record("list_networks");
+            if let Some(e) = &self.fail_with {
+                return Err(e.clone());
+            }
             Ok(self.networks.clone())
         }
 
-        async fn remove_network(&self, name: &str) -> Result<()> {
+        async fn remove_network(&self, name: &str) -> DockerResult<()> {
             self.record(format!("remove_network:{name}"));
             match &self.fail_with {
-                Some(msg) => Err(eyre!(msg.clone())),
+                Some(e) => Err(e.clone()),
                 None => Ok(()),
             }
         }
 
-        async fn list_images(&self) -> Result<Vec<ImageSummary>> {
+        async fn list_images(&self) -> DockerResult<Vec<ImageSummary>> {
             self.record("list_images");
+            if let Some(e) = &self.fail_with {
+                return Err(e.clone());
+            }
             Ok(self.images.clone())
         }
 
-        async fn remove_image(&self, id: &str, force: bool) -> Result<()> {
+        async fn remove_image(&self, id: &str, force: bool) -> DockerResult<()> {
             self.record(format!("remove_image:{id}:{force}"));
             match &self.fail_with {
-                Some(msg) => Err(eyre!(msg.clone())),
+                Some(e) => Err(e.clone()),
                 None => Ok(()),
             }
         }
@@ -500,7 +538,7 @@ mod tests {
         };
         let mut app = App::with_client(mock);
 
-        app.update_containers().await.unwrap();
+        app.update_containers().await;
 
         assert_eq!(app.container_table.table_info().items.len(), 2);
     }
@@ -513,7 +551,7 @@ mod tests {
         };
         let mut app = App::with_client(mock);
 
-        app.update_volumes().await.unwrap();
+        app.update_volumes().await;
 
         assert_eq!(app.volume_table.table_info().items.len(), 2);
     }
@@ -526,7 +564,7 @@ mod tests {
         };
         let mut app = App::with_client(mock);
 
-        app.update_networks().await.unwrap();
+        app.update_networks().await;
 
         assert_eq!(app.network_table.table_info().items.len(), 2);
     }
@@ -542,7 +580,7 @@ mod tests {
         };
         let mut app = App::with_client(mock);
 
-        app.update_images().await.unwrap();
+        app.update_images().await;
 
         assert_eq!(app.image_table.table_info().items.len(), 2);
     }
@@ -550,52 +588,130 @@ mod tests {
     #[tokio::test]
     async fn restart_container_error_is_shown_in_footer() {
         let mock = MockDockerClient {
-            fail_with: Some("a:b:daemon says no".to_string()),
+            fail_with: Some(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
             ..Default::default()
         };
         let mut app = App::with_client(mock);
 
-        app.restart_container("container-id".to_string())
-            .await
-            .unwrap();
+        app.restart_container("container-id".to_string()).await;
 
         let err = app.container_table.table_info().err.clone().unwrap();
-        assert!(err.starts_with("[ERR] "));
-        assert!(err.contains("daemon says no"));
+        assert_eq!(err, "[ERR] Conflict: daemon says no");
+    }
+
+    #[tokio::test]
+    async fn stop_container_error_is_shown_in_footer() {
+        let mock = MockDockerClient {
+            fail_with: Some(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.stop_container("container-id".to_string()).await;
+
+        let err = app.container_table.table_info().err.clone().unwrap();
+        assert_eq!(err, "[ERR] Conflict: daemon says no");
+    }
+
+    #[tokio::test]
+    async fn kill_container_error_is_shown_in_footer() {
+        let mock = MockDockerClient {
+            fail_with: Some(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.kill_container("container-id".to_string()).await;
+
+        let err = app.container_table.table_info().err.clone().unwrap();
+        assert_eq!(err, "[ERR] Conflict: daemon says no");
     }
 
     #[tokio::test]
     async fn remove_volume_error_is_shown_in_footer() {
         let mock = MockDockerClient {
-            fail_with: Some("volume is in use by container [abc123def456]".to_string()),
+            fail_with: Some(DockerError::Conflict {
+                message: "volume is in use".to_string(),
+            }),
             ..Default::default()
         };
         let mut app = App::with_client(mock);
 
-        app.remove_volume("volume-name".to_string(), false)
-            .await
-            .unwrap();
+        app.remove_volume("volume-name".to_string(), false).await;
 
         let err = app.volume_table.table_info().err.clone().unwrap();
-        assert!(err.starts_with("[ERR] "));
-        assert!(err.contains("Volume is in use by container: abc123def456"));
+        assert_eq!(err, "[ERR] Conflict: volume is in use");
     }
 
     #[tokio::test]
     async fn remove_network_error_is_shown_in_footer() {
         let mock = MockDockerClient {
-            fail_with: Some("a:b:daemon says no".to_string()),
+            fail_with: Some(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
             ..Default::default()
         };
         let mut app = App::with_client(mock);
 
-        app.remove_network("network-name".to_string())
-            .await
-            .unwrap();
+        app.remove_network("network-name".to_string()).await;
 
         let err = app.network_table.table_info().err.clone().unwrap();
-        assert!(err.starts_with("[ERR] "));
-        assert!(err.contains("daemon says no"));
+        assert_eq!(err, "[ERR] Conflict: daemon says no");
+    }
+
+    #[tokio::test]
+    async fn remove_image_error_is_shown_in_footer() {
+        let mock = MockDockerClient {
+            fail_with: Some(DockerError::Conflict {
+                message: "daemon says no".to_string(),
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.remove_image("image-id".to_string(), false).await;
+
+        let err = app.image_table.table_info().err.clone().unwrap();
+        assert_eq!(err, "[ERR] Conflict: daemon says no");
+    }
+
+    #[tokio::test]
+    async fn list_failure_shows_error_on_owning_tab() {
+        let mock = MockDockerClient {
+            fail_with: Some(DockerError::DaemonUnreachable {
+                details: "connection refused".to_string(),
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+        assert_eq!(app.selected_tab as usize, SelectedTab::Containers as usize);
+
+        app.update_images().await;
+
+        assert!(app.image_table.table_info().err.is_some());
+        assert!(app.container_table.table_info().err.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_failure_keeps_previous_items() {
+        let mock = MockDockerClient {
+            fail_with: Some(DockerError::DaemonUnreachable {
+                details: "connection refused".to_string(),
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.update_containers().await;
+
+        assert_eq!(app.container_table.table_info().items.len(), 0);
+        assert!(app.container_table.table_info().err.is_some());
     }
 
     #[tokio::test]
@@ -609,9 +725,7 @@ mod tests {
         };
         let mut app = App::with_client(mock);
 
-        app.go_to_container_info("container-id".to_string())
-            .await
-            .unwrap();
+        app.go_to_container_info("container-id".to_string()).await;
         assert!(app.container_info.is_some());
 
         let event = app.handle_key_event(KeyEvent::from(KeyCode::Esc)).unwrap();
@@ -629,9 +743,7 @@ mod tests {
         };
         let mut app = App::with_client(mock);
 
-        app.go_to_container_info("container-id".to_string())
-            .await
-            .unwrap();
+        app.go_to_container_info("container-id".to_string()).await;
 
         let tab_before = app.selected_tab as usize;
         app.handle_key_event(KeyEvent::from(KeyCode::Char('t')))

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,7 @@ use crate::ui::container_table::{ContainerTable, ContainerTableRow};
 use crate::ui::image_table::{ImageTable, ImageTableRow};
 use crate::ui::info_block::ScrollableInfoBlock;
 use crate::ui::network_table::{NetworkTable, NetworkTableRow};
-use crate::ui::resource_table::ResourceTable;
+use crate::ui::resource_table::{ResourceRow, ResourceTable};
 use crate::ui::volume_table::{VolumeTable, VolumeTableRow};
 use color_eyre::eyre::Result;
 use ratatui::Frame;
@@ -215,14 +215,14 @@ impl App {
 
     async fn restart_container(&mut self, container_id: String) -> Result<()> {
         if let Err(e) = self.docker_client.restart_container(&container_id).await {
-            self.container_table.show_container_err(e.to_string());
+            self.container_table.show_err(e.to_string());
         }
         Ok(())
     }
 
     async fn remove_container(&mut self, container_id: String) -> Result<()> {
         if let Err(e) = self.docker_client.remove_container(&container_id).await {
-            self.container_table.show_container_err(e.to_string());
+            self.container_table.show_err(e.to_string());
         }
         Ok(())
     }
@@ -261,21 +261,21 @@ impl App {
 
     async fn remove_volume(&mut self, name: String, force: bool) -> Result<()> {
         if let Err(e) = self.docker_client.remove_volume(&name, force).await {
-            self.volume_table.show_remove_volume_err(e.to_string());
+            self.volume_table.show_err(e.to_string());
         }
         Ok(())
     }
 
     async fn remove_network(&mut self, name: String) -> Result<()> {
         if let Err(e) = self.docker_client.remove_network(&name).await {
-            self.network_table.show_remove_network_err(e.to_string());
+            self.network_table.show_err(e.to_string());
         }
         Ok(())
     }
 
     async fn remove_image(&mut self, id: String, force: bool) -> Result<()> {
         if let Err(e) = self.docker_client.remove_image(&id, force).await {
-            self.image_table.show_remove_image_err(e.to_string());
+            self.image_table.show_err(e.to_string());
         }
         Ok(())
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -342,3 +342,381 @@ impl SelectedTab {
         Self::from_repr(previous_index).unwrap_or(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bollard::secret::{
+        ContainerInspectResponse, ContainerSummary, ImageSummary, Network, Volume,
+        VolumeListResponse,
+    };
+    use color_eyre::eyre::eyre;
+    use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct MockDockerClient {
+        containers: Vec<ContainerSummary>,
+        volumes: Vec<Volume>,
+        networks: Vec<Network>,
+        images: Vec<ImageSummary>,
+        inspect: Option<ContainerInspectResponse>,
+        fail_with: Option<String>,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl MockDockerClient {
+        fn record(&self, call: impl Into<String>) {
+            self.calls.lock().unwrap().push(call.into());
+        }
+    }
+
+    impl DockerApi for MockDockerClient {
+        async fn list_containers(&self) -> Result<Vec<ContainerSummary>> {
+            self.record("list_containers");
+            Ok(self.containers.clone())
+        }
+
+        async fn stop_container(&self, container_id: &str) -> Result<()> {
+            self.record(format!("stop_container:{container_id}"));
+            match &self.fail_with {
+                Some(msg) => Err(eyre!(msg.clone())),
+                None => Ok(()),
+            }
+        }
+
+        async fn restart_container(&self, container_id: &str) -> Result<()> {
+            self.record(format!("restart_container:{container_id}"));
+            match &self.fail_with {
+                Some(msg) => Err(eyre!(msg.clone())),
+                None => Ok(()),
+            }
+        }
+
+        async fn kill_container(&self, container_id: &str) -> Result<()> {
+            self.record(format!("kill_container:{container_id}"));
+            match &self.fail_with {
+                Some(msg) => Err(eyre!(msg.clone())),
+                None => Ok(()),
+            }
+        }
+
+        async fn remove_container(&self, container_id: &str) -> Result<()> {
+            self.record(format!("remove_container:{container_id}"));
+            match &self.fail_with {
+                Some(msg) => Err(eyre!(msg.clone())),
+                None => Ok(()),
+            }
+        }
+
+        async fn inspect_container(&self, container_id: &str) -> Result<ContainerInspectResponse> {
+            self.record(format!("inspect_container:{container_id}"));
+            self.inspect
+                .clone()
+                .ok_or_else(|| eyre!("no inspect data configured"))
+        }
+
+        async fn list_volumes(&self) -> Result<VolumeListResponse> {
+            self.record("list_volumes");
+            Ok(VolumeListResponse {
+                volumes: Some(self.volumes.clone()),
+                ..Default::default()
+            })
+        }
+
+        async fn remove_volume(&self, name: &str, force: bool) -> Result<()> {
+            self.record(format!("remove_volume:{name}:{force}"));
+            match &self.fail_with {
+                Some(msg) => Err(eyre!(msg.clone())),
+                None => Ok(()),
+            }
+        }
+
+        async fn list_networks(&self) -> Result<Vec<Network>> {
+            self.record("list_networks");
+            Ok(self.networks.clone())
+        }
+
+        async fn remove_network(&self, name: &str) -> Result<()> {
+            self.record(format!("remove_network:{name}"));
+            match &self.fail_with {
+                Some(msg) => Err(eyre!(msg.clone())),
+                None => Ok(()),
+            }
+        }
+
+        async fn list_images(&self) -> Result<Vec<ImageSummary>> {
+            self.record("list_images");
+            Ok(self.images.clone())
+        }
+
+        async fn remove_image(&self, id: &str, force: bool) -> Result<()> {
+            self.record(format!("remove_image:{id}:{force}"));
+            match &self.fail_with {
+                Some(msg) => Err(eyre!(msg.clone())),
+                None => Ok(()),
+            }
+        }
+    }
+
+    fn container_summary(id: &str) -> ContainerSummary {
+        ContainerSummary {
+            id: Some(id.to_string()),
+            names: Some(vec![format!("/{id}")]),
+            state: Some("running".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn volume(name: &str) -> Volume {
+        Volume {
+            name: name.to_string(),
+            driver: "local".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn network(id: &str, name: &str) -> Network {
+        Network {
+            id: Some(id.to_string()),
+            name: Some(name.to_string()),
+            driver: Some("bridge".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn image(id: &str) -> ImageSummary {
+        ImageSummary {
+            id: format!("sha256:{id}"),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn update_containers_populates_table() {
+        let mock = MockDockerClient {
+            containers: vec![container_summary("a"), container_summary("b")],
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.update_containers().await.unwrap();
+
+        assert_eq!(app.container_table.table_info().items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn update_volumes_populates_table() {
+        let mock = MockDockerClient {
+            volumes: vec![volume("a"), volume("b")],
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.update_volumes().await.unwrap();
+
+        assert_eq!(app.volume_table.table_info().items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn update_networks_populates_table() {
+        let mock = MockDockerClient {
+            networks: vec![network("111111111111", "a"), network("222222222222", "b")],
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.update_networks().await.unwrap();
+
+        assert_eq!(app.network_table.table_info().items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn update_images_populates_table() {
+        let mock = MockDockerClient {
+            images: vec![
+                image("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"),
+                image("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abce"),
+            ],
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.update_images().await.unwrap();
+
+        assert_eq!(app.image_table.table_info().items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn restart_container_error_is_shown_in_footer() {
+        let mock = MockDockerClient {
+            fail_with: Some("a:b:daemon says no".to_string()),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.restart_container("container-id".to_string())
+            .await
+            .unwrap();
+
+        let err = app.container_table.table_info().err.clone().unwrap();
+        assert!(err.starts_with("[ERR] "));
+        assert!(err.contains("daemon says no"));
+    }
+
+    #[tokio::test]
+    async fn remove_volume_error_is_shown_in_footer() {
+        let mock = MockDockerClient {
+            fail_with: Some("volume is in use by container [abc123def456]".to_string()),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.remove_volume("volume-name".to_string(), false)
+            .await
+            .unwrap();
+
+        let err = app.volume_table.table_info().err.clone().unwrap();
+        assert!(err.starts_with("[ERR] "));
+        assert!(err.contains("Volume is in use by container: abc123def456"));
+    }
+
+    #[tokio::test]
+    async fn remove_network_error_is_shown_in_footer() {
+        let mock = MockDockerClient {
+            fail_with: Some("a:b:daemon says no".to_string()),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.remove_network("network-name".to_string())
+            .await
+            .unwrap();
+
+        let err = app.network_table.table_info().err.clone().unwrap();
+        assert!(err.starts_with("[ERR] "));
+        assert!(err.contains("daemon says no"));
+    }
+
+    #[tokio::test]
+    async fn go_to_container_info_opens_and_back_closes() {
+        let mock = MockDockerClient {
+            inspect: Some(ContainerInspectResponse {
+                id: Some("container-id".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.go_to_container_info("container-id".to_string())
+            .await
+            .unwrap();
+        assert!(app.container_info.is_some());
+
+        let event = app.handle_key_event(KeyEvent::from(KeyCode::Esc)).unwrap();
+        assert!(matches!(event, Some(AppEvent::Back)));
+    }
+
+    #[tokio::test]
+    async fn key_events_route_to_info_block_when_open() {
+        let mock = MockDockerClient {
+            inspect: Some(ContainerInspectResponse {
+                id: Some("container-id".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut app = App::with_client(mock);
+
+        app.go_to_container_info("container-id".to_string())
+            .await
+            .unwrap();
+
+        let tab_before = app.selected_tab as usize;
+        app.handle_key_event(KeyEvent::from(KeyCode::Char('t')))
+            .unwrap();
+        assert_eq!(app.selected_tab as usize, tab_before);
+    }
+
+    #[test]
+    fn ctrl_c_quits() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        let event = app
+            .handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::Quit)));
+
+        app.quit();
+        assert!(!app.running);
+    }
+
+    #[test]
+    fn arrow_and_hjkl_change_tabs() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        assert_eq!(app.selected_tab as usize, SelectedTab::Containers as usize);
+
+        app.handle_key_event(KeyEvent::from(KeyCode::Right))
+            .unwrap();
+        assert_eq!(app.selected_tab as usize, SelectedTab::Volumes as usize);
+
+        app.handle_key_event(KeyEvent::from(KeyCode::Char('l')))
+            .unwrap();
+        assert_eq!(app.selected_tab as usize, SelectedTab::Networks as usize);
+
+        app.handle_key_event(KeyEvent::from(KeyCode::Left)).unwrap();
+        assert_eq!(app.selected_tab as usize, SelectedTab::Volumes as usize);
+
+        app.handle_key_event(KeyEvent::from(KeyCode::Char('h')))
+            .unwrap();
+        assert_eq!(app.selected_tab as usize, SelectedTab::Containers as usize);
+
+        // Saturates at the low end.
+        app.handle_key_event(KeyEvent::from(KeyCode::Left)).unwrap();
+        assert_eq!(app.selected_tab as usize, SelectedTab::Containers as usize);
+
+        // Saturates at the high end.
+        for _ in 0..5 {
+            app.handle_key_event(KeyEvent::from(KeyCode::Right))
+                .unwrap();
+        }
+        assert_eq!(app.selected_tab as usize, SelectedTab::Images as usize);
+    }
+
+    #[test]
+    fn selected_tab_next_and_previous_saturate() {
+        assert_eq!(SelectedTab::Containers.previous() as usize, 0);
+        assert_eq!(
+            SelectedTab::Containers.next() as usize,
+            SelectedTab::Volumes as usize
+        );
+        assert_eq!(
+            SelectedTab::Volumes.next() as usize,
+            SelectedTab::Networks as usize
+        );
+        assert_eq!(
+            SelectedTab::Networks.next() as usize,
+            SelectedTab::Images as usize
+        );
+        assert_eq!(
+            SelectedTab::Images.next() as usize,
+            SelectedTab::Images as usize
+        );
+        assert_eq!(
+            SelectedTab::Volumes.previous() as usize,
+            SelectedTab::Containers as usize
+        );
+    }
+
+    #[test]
+    fn selected_tab_title_renders_padded_name() {
+        assert_eq!(
+            SelectedTab::Containers.title().to_string(),
+            "  Containers  "
+        );
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -35,6 +35,7 @@ pub struct App<C: DockerApi> {
     image_table: ImageTable,
     pending: PendingRefreshes,
     details_requested: bool,
+    dirty: bool,
 }
 
 /// Tracks in-flight list requests so `App` never has more than one outstanding
@@ -62,6 +63,7 @@ impl App<DockerClient> {
             image_table: ImageTable::default(),
             pending: PendingRefreshes::default(),
             details_requested: false,
+            dirty: true,
         })
     }
 }
@@ -84,6 +86,7 @@ impl<C: DockerApi> App<C> {
             image_table: ImageTable::default(),
             pending: PendingRefreshes::default(),
             details_requested: false,
+            dirty: true,
         }
     }
 
@@ -91,7 +94,10 @@ impl<C: DockerApi> App<C> {
         self.request_containers();
 
         while self.running {
-            terminal.draw(|frame| self.draw(frame, frame.area()))?;
+            if self.dirty {
+                terminal.draw(|frame| self.draw(frame, frame.area()))?;
+                self.dirty = false;
+            }
             self.process_next_event().await?;
         }
         Ok(())
@@ -146,31 +152,51 @@ impl<C: DockerApi> App<C> {
                 }
             }
             Event::Crossterm(key_event) => {
+                self.dirty = true;
                 if let Some(event) = self.handle_key_event(key_event)? {
                     self.events.send(event);
                 }
             }
+            Event::Resize => {
+                self.dirty = true;
+            }
             Event::Docker(outcome) => self.apply_docker_outcome(outcome),
-            Event::App(app_event) => match app_event {
-                AppEvent::Quit => self.quit(),
-                AppEvent::UpdateContainers => self.request_containers(),
-                AppEvent::UpdateContainerInfo(id) => self.request_container_details(id),
-                AppEvent::RestartContainer(id) => self.request_restart_container(id),
-                AppEvent::StopContainer(id) => self.request_stop_container(id),
-                AppEvent::KillContainer(id) => self.request_kill_container(id),
-                AppEvent::RemoveContainer(id) => self.request_remove_container(id),
-                AppEvent::GoToContainerDetails(id) => self.request_container_details_open(id),
-                AppEvent::UpdateVolumes => self.request_volumes(),
-                AppEvent::RemoveVolume(name, force) => self.request_remove_volume(name, force),
-                AppEvent::UpdateNetworks => self.request_networks(),
-                AppEvent::RemoveNetwork(name) => self.request_remove_network(name),
-                AppEvent::UpdateImages => self.request_images(),
-                AppEvent::RemoveImage(id, force) => self.request_remove_image(id, force),
-                AppEvent::Back => {
-                    self.details_requested = false;
-                    self.container_info = None;
+            Event::App(app_event) => {
+                if matches!(
+                    app_event,
+                    AppEvent::Back
+                        | AppEvent::RestartContainer(_)
+                        | AppEvent::StopContainer(_)
+                        | AppEvent::KillContainer(_)
+                        | AppEvent::RemoveContainer(_)
+                        | AppEvent::RemoveVolume(..)
+                        | AppEvent::RemoveNetwork(_)
+                        | AppEvent::RemoveImage(..)
+                ) {
+                    self.dirty = true;
                 }
-            },
+
+                match app_event {
+                    AppEvent::Quit => self.quit(),
+                    AppEvent::UpdateContainers => self.request_containers(),
+                    AppEvent::UpdateContainerInfo(id) => self.request_container_details(id),
+                    AppEvent::RestartContainer(id) => self.request_restart_container(id),
+                    AppEvent::StopContainer(id) => self.request_stop_container(id),
+                    AppEvent::KillContainer(id) => self.request_kill_container(id),
+                    AppEvent::RemoveContainer(id) => self.request_remove_container(id),
+                    AppEvent::GoToContainerDetails(id) => self.request_container_details_open(id),
+                    AppEvent::UpdateVolumes => self.request_volumes(),
+                    AppEvent::RemoveVolume(name, force) => self.request_remove_volume(name, force),
+                    AppEvent::UpdateNetworks => self.request_networks(),
+                    AppEvent::RemoveNetwork(name) => self.request_remove_network(name),
+                    AppEvent::UpdateImages => self.request_images(),
+                    AppEvent::RemoveImage(id, force) => self.request_remove_image(id, force),
+                    AppEvent::Back => {
+                        self.details_requested = false;
+                        self.container_info = None;
+                    }
+                }
+            }
         }
         Ok(())
     }
@@ -232,12 +258,13 @@ impl<C: DockerApi> App<C> {
     }
 
     fn report_err(&mut self, tab: SelectedTab, err: &DockerError) {
-        match tab {
+        let changed = match tab {
             SelectedTab::Containers => self.container_table.show_err(err),
             SelectedTab::Volumes => self.volume_table.show_err(err),
             SelectedTab::Networks => self.network_table.show_err(err),
             SelectedTab::Images => self.image_table.show_err(err),
-        }
+        };
+        self.dirty |= changed;
     }
 
     /// Unwraps a Docker result, reporting failures into `tab`'s footer.
@@ -268,6 +295,7 @@ impl<C: DockerApi> App<C> {
             SelectedTab::Networks => self.network_table.begin_pending_op(),
             SelectedTab::Images => self.image_table.begin_pending_op(),
         }
+        self.dirty = true;
     }
 
     fn end_action(&mut self, tab: SelectedTab) {
@@ -277,6 +305,7 @@ impl<C: DockerApi> App<C> {
             SelectedTab::Networks => self.network_table.end_pending_op(),
             SelectedTab::Images => self.image_table.end_pending_op(),
         }
+        self.dirty = true;
     }
 
     /// Runs a Docker operation off the event loop; its outcome comes back as `Event::Docker`.
@@ -428,7 +457,8 @@ impl<C: DockerApi> App<C> {
             DockerOutcome::ContainersListed(result) => {
                 self.pending.containers = false;
                 if let Some(list) = self.ok_or_report(SelectedTab::Containers, result) {
-                    self.container_table
+                    self.dirty |= self
+                        .container_table
                         .update_with_items(ContainerTableRow::from_list(list));
                 }
             }
@@ -437,21 +467,24 @@ impl<C: DockerApi> App<C> {
                 if let Some(response) = self.ok_or_report(SelectedTab::Volumes, result)
                     && let Some(volumes) = response.volumes
                 {
-                    self.volume_table
+                    self.dirty |= self
+                        .volume_table
                         .update_with_items(VolumeTableRow::from_list(volumes));
                 }
             }
             DockerOutcome::NetworksListed(result) => {
                 self.pending.networks = false;
                 if let Some(list) = self.ok_or_report(SelectedTab::Networks, result) {
-                    self.network_table
+                    self.dirty |= self
+                        .network_table
                         .update_with_items(NetworkTableRow::from_list(list));
                 }
             }
             DockerOutcome::ImagesListed(result) => {
                 self.pending.images = false;
                 if let Some(list) = self.ok_or_report(SelectedTab::Images, result) {
-                    self.image_table
+                    self.dirty |= self
+                        .image_table
                         .update_with_items(ImageTableRow::from_list(list));
                 }
             }
@@ -475,8 +508,9 @@ impl<C: DockerApi> App<C> {
                     let mut container_info_block = ContainerInfoBlock::default();
                     container_info_block.update_data(data);
                     self.container_info = Some(Box::new(container_info_block));
+                    self.dirty = true;
                 } else if let Some(block) = self.container_info.as_mut() {
-                    block.update_data(data);
+                    self.dirty |= block.update_data(data);
                 }
             }
             DockerOutcome::ActionCompleted { resource, result } => {
@@ -534,8 +568,8 @@ impl SelectedTab {
 mod tests {
     use super::*;
     use bollard::secret::{
-        ContainerInspectResponse, ContainerSummary, ImageSummary, Network, Volume,
-        VolumeListResponse,
+        ContainerInspectResponse, ContainerStateStatusEnum, ContainerSummary, ImageSummary,
+        Network, Volume, VolumeListResponse,
     };
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use std::sync::{Arc, Mutex};
@@ -1108,5 +1142,153 @@ mod tests {
             SelectedTab::Containers.title().to_string(),
             "  Containers  "
         );
+    }
+
+    #[test]
+    fn app_starts_dirty() {
+        let mock = MockDockerClient::default();
+        let app = App::with_client(mock);
+        assert!(app.dirty);
+    }
+
+    #[tokio::test]
+    async fn tick_does_not_mark_dirty() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+        app.dirty = false;
+
+        app.events.sender().send(Event::Tick).unwrap();
+        app.process_next_event().await.unwrap();
+
+        assert!(!app.dirty);
+    }
+
+    #[tokio::test]
+    async fn key_event_marks_dirty() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+        app.dirty = false;
+
+        app.events
+            .sender()
+            .send(Event::Crossterm(KeyEvent::from(KeyCode::Right)))
+            .unwrap();
+        app.process_next_event().await.unwrap();
+
+        assert!(app.dirty);
+    }
+
+    #[tokio::test]
+    async fn resize_event_marks_dirty() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+        app.dirty = false;
+
+        app.events.sender().send(Event::Resize).unwrap();
+        app.process_next_event().await.unwrap();
+
+        assert!(app.dirty);
+        assert!(app.running);
+    }
+
+    #[test]
+    fn unchanged_container_list_does_not_mark_dirty() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        app.apply_docker_outcome(DockerOutcome::ContainersListed(Ok(vec![
+            container_summary("a"),
+        ])));
+        app.dirty = false;
+
+        app.apply_docker_outcome(DockerOutcome::ContainersListed(Ok(vec![
+            container_summary("a"),
+        ])));
+        assert!(!app.dirty);
+
+        app.apply_docker_outcome(DockerOutcome::ContainersListed(Ok(vec![
+            container_summary("a"),
+            container_summary("b"),
+        ])));
+        assert!(app.dirty);
+    }
+
+    #[test]
+    fn list_error_marks_dirty_once() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        app.apply_docker_outcome(DockerOutcome::ContainersListed(Err(
+            DockerError::DaemonUnreachable {
+                details: "connection refused".to_string(),
+            },
+        )));
+        assert!(app.dirty);
+        app.dirty = false;
+
+        app.apply_docker_outcome(DockerOutcome::ContainersListed(Err(
+            DockerError::DaemonUnreachable {
+                details: "connection refused".to_string(),
+            },
+        )));
+        assert!(!app.dirty);
+    }
+
+    #[tokio::test]
+    async fn action_request_and_completion_mark_dirty() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+        app.dirty = false;
+
+        app.request_stop_container("container-id".to_string());
+        assert!(app.dirty);
+        app.dirty = false;
+
+        app.apply_docker_outcome(DockerOutcome::ActionCompleted {
+            resource: ResourceKind::Containers,
+            result: Ok(()),
+        });
+        assert!(app.dirty);
+    }
+
+    #[tokio::test]
+    async fn container_info_refresh_with_identical_data_does_not_mark_dirty() {
+        let mock = MockDockerClient::default();
+        let mut app = App::with_client(mock);
+
+        app.request_container_details_open("container-id".to_string());
+        let inspect = ContainerInspectResponse {
+            id: Some("container-id".to_string()),
+            state: Some(bollard::secret::ContainerState {
+                status: Some(ContainerStateStatusEnum::RUNNING),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        app.apply_docker_outcome(DockerOutcome::ContainerInspected {
+            open_details: true,
+            result: Ok(Box::new(inspect.clone())),
+        });
+        assert!(app.container_info.is_some());
+        app.dirty = false;
+
+        app.apply_docker_outcome(DockerOutcome::ContainerInspected {
+            open_details: false,
+            result: Ok(Box::new(inspect.clone())),
+        });
+        assert!(!app.dirty);
+
+        let changed_inspect = ContainerInspectResponse {
+            state: Some(bollard::secret::ContainerState {
+                status: Some(ContainerStateStatusEnum::EXITED),
+                ..Default::default()
+            }),
+            ..inspect
+        };
+        app.apply_docker_outcome(DockerOutcome::ContainerInspected {
+            open_details: false,
+            result: Ok(Box::new(changed_inspect)),
+        });
+        assert!(app.dirty);
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -205,10 +205,10 @@ impl App {
     }
 
     async fn update_container_details(&mut self, container_id: String) -> Result<()> {
-        if let Some(data) = self.get_container_data(container_id).await {
-            if let Some(info_block) = self.container_info.as_mut() {
-                info_block.update_data(data);
-            }
+        if let Some(data) = self.get_container_data(container_id).await
+            && let Some(info_block) = self.container_info.as_mut()
+        {
+            info_block.update_data(data);
         }
         Ok(())
     }

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -21,8 +21,28 @@ impl DockerClient {
             client: Docker::connect_with_local_defaults()?,
         })
     }
+}
 
-    pub async fn list_containers(&self) -> Result<Vec<ContainerSummary>> {
+/// Crate-internal trait, App is awaited directly by #[tokio::main] and never
+/// tokio::spawn-ed, so no Send bound is required.
+#[allow(async_fn_in_trait)]
+pub trait DockerApi {
+    async fn list_containers(&self) -> Result<Vec<ContainerSummary>>;
+    async fn stop_container(&self, container_id: &str) -> Result<()>;
+    async fn restart_container(&self, container_id: &str) -> Result<()>;
+    async fn kill_container(&self, container_id: &str) -> Result<()>;
+    async fn remove_container(&self, container_id: &str) -> Result<()>;
+    async fn inspect_container(&self, container_id: &str) -> Result<ContainerInspectResponse>;
+    async fn list_volumes(&self) -> Result<VolumeListResponse>;
+    async fn remove_volume(&self, name: &str, force: bool) -> Result<()>;
+    async fn list_networks(&self) -> Result<Vec<Network>>;
+    async fn remove_network(&self, name: &str) -> Result<()>;
+    async fn list_images(&self) -> Result<Vec<ImageSummary>>;
+    async fn remove_image(&self, id: &str, force: bool) -> Result<()>;
+}
+
+impl DockerApi for DockerClient {
+    async fn list_containers(&self) -> Result<Vec<ContainerSummary>> {
         Ok(self
             .client
             .list_containers(Some(ListContainersOptions::<String> {
@@ -32,28 +52,28 @@ impl DockerClient {
             .await?)
     }
 
-    pub async fn stop_container(&self, container_id: &str) -> Result<()> {
+    async fn stop_container(&self, container_id: &str) -> Result<()> {
         self.client
             .stop_container(container_id, None::<StopContainerOptions>)
             .await?;
         Ok(())
     }
 
-    pub async fn restart_container(&self, container_id: &str) -> Result<()> {
+    async fn restart_container(&self, container_id: &str) -> Result<()> {
         self.client
             .restart_container(container_id, None::<RestartContainerOptions>)
             .await?;
         Ok(())
     }
 
-    pub async fn kill_container(&self, container_id: &str) -> Result<()> {
+    async fn kill_container(&self, container_id: &str) -> Result<()> {
         self.client
             .kill_container(container_id, None::<KillContainerOptions<String>>)
             .await?;
         Ok(())
     }
 
-    pub async fn remove_container(&self, container_id: &str) -> Result<()> {
+    async fn remove_container(&self, container_id: &str) -> Result<()> {
         self.client
             .remove_container(
                 container_id,
@@ -66,39 +86,39 @@ impl DockerClient {
         Ok(())
     }
 
-    pub async fn inspect_container(&self, container_id: &str) -> Result<ContainerInspectResponse> {
+    async fn inspect_container(&self, container_id: &str) -> Result<ContainerInspectResponse> {
         Ok(self
             .client
             .inspect_container(container_id, None::<InspectContainerOptions>)
             .await?)
     }
 
-    pub async fn list_volumes(&self) -> Result<VolumeListResponse> {
+    async fn list_volumes(&self) -> Result<VolumeListResponse> {
         Ok(self
             .client
             .list_volumes(Some(ListVolumesOptions::<String>::default()))
             .await?)
     }
 
-    pub async fn remove_volume(&self, name: &str, force: bool) -> Result<()> {
+    async fn remove_volume(&self, name: &str, force: bool) -> Result<()> {
         Ok(self
             .client
             .remove_volume(name, Some(RemoveVolumeOptions { force }))
             .await?)
     }
 
-    pub async fn list_networks(&self) -> Result<Vec<Network>> {
+    async fn list_networks(&self) -> Result<Vec<Network>> {
         Ok(self
             .client
             .list_networks(Some(ListNetworksOptions::<String>::default()))
             .await?)
     }
 
-    pub async fn remove_network(&self, name: &str) -> Result<()> {
+    async fn remove_network(&self, name: &str) -> Result<()> {
         Ok(self.client.remove_network(name).await?)
     }
 
-    pub async fn list_images(&self) -> Result<Vec<ImageSummary>> {
+    async fn list_images(&self) -> Result<Vec<ImageSummary>> {
         let options = Some(ListImagesOptions::<String> {
             all: true,
             ..Default::default()
@@ -106,7 +126,7 @@ impl DockerClient {
         Ok(self.client.list_images(options).await?)
     }
 
-    pub async fn remove_image(&self, id: &str, force: bool) -> Result<()> {
+    async fn remove_image(&self, id: &str, force: bool) -> Result<()> {
         let options = Some(RemoveImageOptions {
             force,
             ..Default::default()

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -9,6 +9,7 @@ use bollard::network::ListNetworksOptions;
 use bollard::secret::{ContainerInspectResponse, ImageSummary, Network, VolumeListResponse};
 use bollard::volume::{ListVolumesOptions, RemoveVolumeOptions};
 use color_eyre::eyre::Result;
+use std::future::Future;
 
 use crate::docker::error::DockerResult;
 
@@ -25,23 +26,32 @@ impl DockerClient {
     }
 }
 
-/// Crate-internal trait, App is awaited directly by #[tokio::main] and never
-/// tokio::spawn-ed, so no Send bound is required.
-#[allow(async_fn_in_trait)]
-pub trait DockerApi {
-    async fn list_containers(&self) -> DockerResult<Vec<ContainerSummary>>;
-    async fn stop_container(&self, container_id: &str) -> DockerResult<()>;
-    async fn restart_container(&self, container_id: &str) -> DockerResult<()>;
-    async fn kill_container(&self, container_id: &str) -> DockerResult<()>;
-    async fn remove_container(&self, container_id: &str) -> DockerResult<()>;
-    async fn inspect_container(&self, container_id: &str)
-    -> DockerResult<ContainerInspectResponse>;
-    async fn list_volumes(&self) -> DockerResult<VolumeListResponse>;
-    async fn remove_volume(&self, name: &str, force: bool) -> DockerResult<()>;
-    async fn list_networks(&self) -> DockerResult<Vec<Network>>;
-    async fn remove_network(&self, name: &str) -> DockerResult<()>;
-    async fn list_images(&self) -> DockerResult<Vec<ImageSummary>>;
-    async fn remove_image(&self, id: &str, force: bool) -> DockerResult<()>;
+/// Crate-internal Docker surface. Methods return `Send` futures because `App`
+/// spawns them as background tasks (see `App::spawn_docker`).
+pub trait DockerApi: Clone + Send + Sync + 'static {
+    fn list_containers(&self) -> impl Future<Output = DockerResult<Vec<ContainerSummary>>> + Send;
+    fn stop_container(&self, container_id: &str) -> impl Future<Output = DockerResult<()>> + Send;
+    fn restart_container(
+        &self,
+        container_id: &str,
+    ) -> impl Future<Output = DockerResult<()>> + Send;
+    fn kill_container(&self, container_id: &str) -> impl Future<Output = DockerResult<()>> + Send;
+    fn remove_container(&self, container_id: &str)
+    -> impl Future<Output = DockerResult<()>> + Send;
+    fn inspect_container(
+        &self,
+        container_id: &str,
+    ) -> impl Future<Output = DockerResult<ContainerInspectResponse>> + Send;
+    fn list_volumes(&self) -> impl Future<Output = DockerResult<VolumeListResponse>> + Send;
+    fn remove_volume(
+        &self,
+        name: &str,
+        force: bool,
+    ) -> impl Future<Output = DockerResult<()>> + Send;
+    fn list_networks(&self) -> impl Future<Output = DockerResult<Vec<Network>>> + Send;
+    fn remove_network(&self, name: &str) -> impl Future<Output = DockerResult<()>> + Send;
+    fn list_images(&self) -> impl Future<Output = DockerResult<Vec<ImageSummary>>> + Send;
+    fn remove_image(&self, id: &str, force: bool) -> impl Future<Output = DockerResult<()>> + Send;
 }
 
 impl DockerApi for DockerClient {

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -74,15 +74,24 @@ impl DockerClient {
     }
 
     pub async fn list_volumes(&self) -> Result<VolumeListResponse> {
-        Ok(self.client.list_volumes(Some(ListVolumesOptions::<String>::default())).await?)
+        Ok(self
+            .client
+            .list_volumes(Some(ListVolumesOptions::<String>::default()))
+            .await?)
     }
 
     pub async fn remove_volume(&self, name: &str, force: bool) -> Result<()> {
-        Ok(self.client.remove_volume(name, Some(RemoveVolumeOptions { force })).await?)
+        Ok(self
+            .client
+            .remove_volume(name, Some(RemoveVolumeOptions { force }))
+            .await?)
     }
 
     pub async fn list_networks(&self) -> Result<Vec<Network>> {
-        Ok(self.client.list_networks(Some(ListNetworksOptions::<String>::default())).await?)
+        Ok(self
+            .client
+            .list_networks(Some(ListNetworksOptions::<String>::default()))
+            .await?)
     }
 
     pub async fn remove_network(&self, name: &str) -> Result<()> {
@@ -90,12 +99,18 @@ impl DockerClient {
     }
 
     pub async fn list_images(&self) -> Result<Vec<ImageSummary>> {
-        let options = Some(ListImagesOptions::<String> { all: true, ..Default::default() });
+        let options = Some(ListImagesOptions::<String> {
+            all: true,
+            ..Default::default()
+        });
         Ok(self.client.list_images(options).await?)
     }
 
     pub async fn remove_image(&self, id: &str, force: bool) -> Result<()> {
-        let options = Some(RemoveImageOptions { force, ..Default::default() });
+        let options = Some(RemoveImageOptions {
+            force,
+            ..Default::default()
+        });
         self.client.remove_image(id, options, None).await?;
         Ok(())
     }

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -10,6 +10,8 @@ use bollard::secret::{ContainerInspectResponse, ImageSummary, Network, VolumeLis
 use bollard::volume::{ListVolumesOptions, RemoveVolumeOptions};
 use color_eyre::eyre::Result;
 
+use crate::docker::error::DockerResult;
+
 #[derive(Clone)]
 pub struct DockerClient {
     client: Docker,
@@ -27,22 +29,23 @@ impl DockerClient {
 /// tokio::spawn-ed, so no Send bound is required.
 #[allow(async_fn_in_trait)]
 pub trait DockerApi {
-    async fn list_containers(&self) -> Result<Vec<ContainerSummary>>;
-    async fn stop_container(&self, container_id: &str) -> Result<()>;
-    async fn restart_container(&self, container_id: &str) -> Result<()>;
-    async fn kill_container(&self, container_id: &str) -> Result<()>;
-    async fn remove_container(&self, container_id: &str) -> Result<()>;
-    async fn inspect_container(&self, container_id: &str) -> Result<ContainerInspectResponse>;
-    async fn list_volumes(&self) -> Result<VolumeListResponse>;
-    async fn remove_volume(&self, name: &str, force: bool) -> Result<()>;
-    async fn list_networks(&self) -> Result<Vec<Network>>;
-    async fn remove_network(&self, name: &str) -> Result<()>;
-    async fn list_images(&self) -> Result<Vec<ImageSummary>>;
-    async fn remove_image(&self, id: &str, force: bool) -> Result<()>;
+    async fn list_containers(&self) -> DockerResult<Vec<ContainerSummary>>;
+    async fn stop_container(&self, container_id: &str) -> DockerResult<()>;
+    async fn restart_container(&self, container_id: &str) -> DockerResult<()>;
+    async fn kill_container(&self, container_id: &str) -> DockerResult<()>;
+    async fn remove_container(&self, container_id: &str) -> DockerResult<()>;
+    async fn inspect_container(&self, container_id: &str)
+    -> DockerResult<ContainerInspectResponse>;
+    async fn list_volumes(&self) -> DockerResult<VolumeListResponse>;
+    async fn remove_volume(&self, name: &str, force: bool) -> DockerResult<()>;
+    async fn list_networks(&self) -> DockerResult<Vec<Network>>;
+    async fn remove_network(&self, name: &str) -> DockerResult<()>;
+    async fn list_images(&self) -> DockerResult<Vec<ImageSummary>>;
+    async fn remove_image(&self, id: &str, force: bool) -> DockerResult<()>;
 }
 
 impl DockerApi for DockerClient {
-    async fn list_containers(&self) -> Result<Vec<ContainerSummary>> {
+    async fn list_containers(&self) -> DockerResult<Vec<ContainerSummary>> {
         Ok(self
             .client
             .list_containers(Some(ListContainersOptions::<String> {
@@ -52,28 +55,28 @@ impl DockerApi for DockerClient {
             .await?)
     }
 
-    async fn stop_container(&self, container_id: &str) -> Result<()> {
+    async fn stop_container(&self, container_id: &str) -> DockerResult<()> {
         self.client
             .stop_container(container_id, None::<StopContainerOptions>)
             .await?;
         Ok(())
     }
 
-    async fn restart_container(&self, container_id: &str) -> Result<()> {
+    async fn restart_container(&self, container_id: &str) -> DockerResult<()> {
         self.client
             .restart_container(container_id, None::<RestartContainerOptions>)
             .await?;
         Ok(())
     }
 
-    async fn kill_container(&self, container_id: &str) -> Result<()> {
+    async fn kill_container(&self, container_id: &str) -> DockerResult<()> {
         self.client
             .kill_container(container_id, None::<KillContainerOptions<String>>)
             .await?;
         Ok(())
     }
 
-    async fn remove_container(&self, container_id: &str) -> Result<()> {
+    async fn remove_container(&self, container_id: &str) -> DockerResult<()> {
         self.client
             .remove_container(
                 container_id,
@@ -86,39 +89,42 @@ impl DockerApi for DockerClient {
         Ok(())
     }
 
-    async fn inspect_container(&self, container_id: &str) -> Result<ContainerInspectResponse> {
+    async fn inspect_container(
+        &self,
+        container_id: &str,
+    ) -> DockerResult<ContainerInspectResponse> {
         Ok(self
             .client
             .inspect_container(container_id, None::<InspectContainerOptions>)
             .await?)
     }
 
-    async fn list_volumes(&self) -> Result<VolumeListResponse> {
+    async fn list_volumes(&self) -> DockerResult<VolumeListResponse> {
         Ok(self
             .client
             .list_volumes(Some(ListVolumesOptions::<String>::default()))
             .await?)
     }
 
-    async fn remove_volume(&self, name: &str, force: bool) -> Result<()> {
+    async fn remove_volume(&self, name: &str, force: bool) -> DockerResult<()> {
         Ok(self
             .client
             .remove_volume(name, Some(RemoveVolumeOptions { force }))
             .await?)
     }
 
-    async fn list_networks(&self) -> Result<Vec<Network>> {
+    async fn list_networks(&self) -> DockerResult<Vec<Network>> {
         Ok(self
             .client
             .list_networks(Some(ListNetworksOptions::<String>::default()))
             .await?)
     }
 
-    async fn remove_network(&self, name: &str) -> Result<()> {
+    async fn remove_network(&self, name: &str) -> DockerResult<()> {
         Ok(self.client.remove_network(name).await?)
     }
 
-    async fn list_images(&self) -> Result<Vec<ImageSummary>> {
+    async fn list_images(&self) -> DockerResult<Vec<ImageSummary>> {
         let options = Some(ListImagesOptions::<String> {
             all: true,
             ..Default::default()
@@ -126,7 +132,7 @@ impl DockerApi for DockerClient {
         Ok(self.client.list_images(options).await?)
     }
 
-    async fn remove_image(&self, id: &str, force: bool) -> Result<()> {
+    async fn remove_image(&self, id: &str, force: bool) -> DockerResult<()> {
         let options = Some(RemoveImageOptions {
             force,
             ..Default::default()

--- a/src/docker/error.rs
+++ b/src/docker/error.rs
@@ -1,0 +1,149 @@
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum DockerError {
+    #[error("Not found: {message}")]
+    NotFound { message: String },
+    #[error("Conflict: {message}")]
+    Conflict { message: String },
+    #[error("Cannot reach the Docker daemon ({details})")]
+    DaemonUnreachable { details: String },
+    #[error("Docker error {status_code}: {message}")]
+    Server { status_code: u16, message: String },
+    #[error("Something went wrong: {message}")]
+    Other { message: String },
+}
+
+pub type DockerResult<T> = std::result::Result<T, DockerError>;
+
+impl From<bollard::errors::Error> for DockerError {
+    fn from(err: bollard::errors::Error) -> Self {
+        match &err {
+            bollard::errors::Error::DockerResponseServerError {
+                status_code: 404,
+                message,
+            } => DockerError::NotFound {
+                message: message.clone(),
+            },
+            bollard::errors::Error::DockerResponseServerError {
+                status_code: 409,
+                message,
+            } => DockerError::Conflict {
+                message: message.clone(),
+            },
+            bollard::errors::Error::DockerResponseServerError {
+                status_code,
+                message,
+            } => DockerError::Server {
+                status_code: *status_code,
+                message: message.clone(),
+            },
+            bollard::errors::Error::SocketNotFoundError(_)
+            | bollard::errors::Error::UnsupportedURISchemeError { .. }
+            | bollard::errors::Error::IOError { .. }
+            | bollard::errors::Error::HyperResponseError { .. }
+            | bollard::errors::Error::RequestTimeoutError => DockerError::DaemonUnreachable {
+                details: err.to_string(),
+            },
+            _ => DockerError::Other {
+                message: err.to_string(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_error_404_maps_to_not_found() {
+        let err = bollard::errors::Error::DockerResponseServerError {
+            status_code: 404,
+            message: "No such volume: foo".into(),
+        };
+        let mapped: DockerError = err.into();
+        assert_eq!(
+            mapped,
+            DockerError::NotFound {
+                message: "No such volume: foo".into()
+            }
+        );
+        assert_eq!(mapped.to_string(), "Not found: No such volume: foo");
+    }
+
+    #[test]
+    fn server_error_409_maps_to_conflict() {
+        let err = bollard::errors::Error::DockerResponseServerError {
+            status_code: 409,
+            message: "remove foo: volume is in use - [abc123def456]".into(),
+        };
+        let mapped: DockerError = err.into();
+        assert_eq!(
+            mapped,
+            DockerError::Conflict {
+                message: "remove foo: volume is in use - [abc123def456]".into()
+            }
+        );
+        assert_eq!(
+            mapped.to_string(),
+            "Conflict: remove foo: volume is in use - [abc123def456]"
+        );
+    }
+
+    #[test]
+    fn other_status_codes_map_to_server() {
+        let err = bollard::errors::Error::DockerResponseServerError {
+            status_code: 500,
+            message: "internal server error".into(),
+        };
+        let mapped: DockerError = err.into();
+        assert_eq!(
+            mapped,
+            DockerError::Server {
+                status_code: 500,
+                message: "internal server error".into()
+            }
+        );
+        assert_eq!(
+            mapped.to_string(),
+            "Docker error 500: internal server error"
+        );
+    }
+
+    #[test]
+    fn socket_not_found_and_timeout_map_to_daemon_unreachable() {
+        let socket_err: DockerError =
+            bollard::errors::Error::SocketNotFoundError("/var/run/docker.sock".into()).into();
+        assert!(matches!(socket_err, DockerError::DaemonUnreachable { .. }));
+        assert!(
+            socket_err
+                .to_string()
+                .starts_with("Cannot reach the Docker daemon (")
+        );
+
+        let timeout_err: DockerError = bollard::errors::Error::RequestTimeoutError.into();
+        assert!(matches!(timeout_err, DockerError::DaemonUnreachable { .. }));
+        assert!(
+            timeout_err
+                .to_string()
+                .starts_with("Cannot reach the Docker daemon (")
+        );
+
+        let io_err: DockerError = bollard::errors::Error::IOError {
+            err: std::io::Error::from(std::io::ErrorKind::ConnectionRefused),
+        }
+        .into();
+        assert!(matches!(io_err, DockerError::DaemonUnreachable { .. }));
+        assert!(
+            io_err
+                .to_string()
+                .starts_with("Cannot reach the Docker daemon (")
+        );
+    }
+
+    #[test]
+    fn unmapped_variants_fall_back_to_other() {
+        let err: DockerError = bollard::errors::Error::APIVersionParseError {}.into();
+        assert!(matches!(err, DockerError::Other { .. }));
+        assert!(err.to_string().starts_with("Something went wrong: "));
+    }
+}

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -1,1 +1,2 @@
 pub mod client;
+pub mod models;

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -1,2 +1,3 @@
 pub mod client;
+pub mod error;
 pub mod models;

--- a/src/docker/models.rs
+++ b/src/docker/models.rs
@@ -1,0 +1,369 @@
+use std::collections::HashMap;
+use std::fmt;
+
+use bollard::secret::{
+    ContainerStateStatusEnum, MountPoint, MountPointTypeEnum, Port, PortBinding, PortTypeEnum,
+};
+
+/// Parses the loosely-typed `state` string coming from the Docker API into the
+/// typed enum, falling back to `EMPTY` when missing or unrecognized.
+pub fn parse_container_state(state: Option<&str>) -> ContainerStateStatusEnum {
+    state
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(ContainerStateStatusEnum::EMPTY)
+}
+
+/// Human-readable label for a container state, used only for table rendering.
+pub fn state_label(state: ContainerStateStatusEnum) -> String {
+    if state == ContainerStateStatusEnum::EMPTY {
+        "-".to_string()
+    } else {
+        state.to_string()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PortMapping {
+    pub private: u16,
+    pub public: u16,
+    pub protocol: PortTypeEnum,
+}
+
+impl fmt::Display for PortMapping {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}/{}", self.private, self.public, self.protocol)
+    }
+}
+
+impl PortMapping {
+    pub fn from_summary_ports(ports: &[Port]) -> Vec<PortMapping> {
+        let mut filtered_ports: Vec<PortMapping> = ports
+            .iter()
+            .filter_map(|p| {
+                Some(PortMapping {
+                    private: p.private_port,
+                    public: p.public_port?,
+                    protocol: p.typ?,
+                })
+            })
+            .collect();
+
+        filtered_ports.sort_by_key(|p| p.private);
+        filtered_ports.dedup();
+
+        filtered_ports
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostBinding {
+    pub host_ip: String,
+    pub host_port: String,
+}
+
+impl fmt::Display for HostBinding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.host_ip, self.host_port)
+    }
+}
+
+impl HostBinding {
+    fn from_binding(binding: &PortBinding) -> HostBinding {
+        HostBinding {
+            host_ip: binding.host_ip.clone().unwrap_or_default(),
+            host_port: binding.host_port.clone().unwrap_or_default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortConfig {
+    pub container_port: String,
+    pub protocol: String,
+    pub ipv4: Option<HostBinding>,
+    pub ipv6: Option<HostBinding>,
+}
+
+impl fmt::Display for PortConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (&self.ipv4, &self.ipv6) {
+            (Some(ipv4), Some(ipv6)) => write!(
+                f,
+                "{ipv4} | {ipv6} -> {}/{}",
+                self.container_port, self.protocol
+            ),
+            (Some(ipv4), None) => {
+                write!(f, "{ipv4} -> {}/{}", self.container_port, self.protocol)
+            }
+            (None, Some(ipv6)) => {
+                write!(f, "{ipv6} -> {}/{}", self.container_port, self.protocol)
+            }
+            (None, None) => write!(f, ""),
+        }
+    }
+}
+
+impl PortConfig {
+    pub fn from_port_map(ports: &HashMap<String, Option<Vec<PortBinding>>>) -> Vec<PortConfig> {
+        ports
+            .iter()
+            .filter_map(|(port, bindings)| {
+                let (ipv4_binding, ipv6_binding) = bindings
+                    .as_ref()
+                    .map(|b| {
+                        let ipv4 = b
+                            .iter()
+                            .find(|pb| pb.host_ip == Some("0.0.0.0".to_string()));
+                        let ipv6 = b.iter().find(|pb| pb.host_ip == Some("::".to_string()));
+                        (ipv4, ipv6)
+                    })
+                    .unwrap_or((None, None));
+
+                let ipv4 = ipv4_binding.map(HostBinding::from_binding);
+                let ipv6 = ipv6_binding.map(HostBinding::from_binding);
+
+                if ipv4.is_none() && ipv6.is_none() {
+                    return None;
+                }
+
+                let container_port = port.split('/').next().unwrap_or("").to_string();
+                let protocol = port.split('/').nth(1).unwrap_or("").to_string();
+
+                Some(PortConfig {
+                    container_port,
+                    protocol,
+                    ipv4,
+                    ipv6,
+                })
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Mount {
+    pub source: String,
+    pub destination: String,
+}
+
+impl fmt::Display for Mount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} -> {}", self.source, self.destination)
+    }
+}
+
+impl Mount {
+    pub fn from_mount_points(mount_points: &[MountPoint]) -> Vec<Mount> {
+        mount_points
+            .iter()
+            .map(|mp| {
+                let source = match mp.typ {
+                    Some(MountPointTypeEnum::VOLUME) => {
+                        mp.name.clone().unwrap_or_else(|| "-".to_string())
+                    }
+                    Some(_) => mp.source.clone().unwrap_or_else(|| "-".to_string()),
+                    None => "-".to_string(),
+                };
+
+                let destination = mp.destination.clone().unwrap_or_else(|| "-".to_string());
+
+                Mount {
+                    source,
+                    destination,
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_container_state_recognizes_known_values() {
+        assert_eq!(
+            parse_container_state(Some("running")),
+            ContainerStateStatusEnum::RUNNING
+        );
+        assert_eq!(
+            parse_container_state(Some("restarting")),
+            ContainerStateStatusEnum::RESTARTING
+        );
+    }
+
+    #[test]
+    fn parse_container_state_falls_back_to_empty() {
+        assert_eq!(parse_container_state(None), ContainerStateStatusEnum::EMPTY);
+        assert_eq!(
+            parse_container_state(Some("bogus")),
+            ContainerStateStatusEnum::EMPTY
+        );
+    }
+
+    #[test]
+    fn state_label_formats_correctly() {
+        assert_eq!(state_label(ContainerStateStatusEnum::EMPTY), "-");
+        assert_eq!(state_label(ContainerStateStatusEnum::RUNNING), "running");
+    }
+
+    #[test]
+    fn port_mapping_filters_sorts_and_dedups() {
+        let ports = vec![
+            Port {
+                private_port: 8080,
+                public_port: Some(80),
+                typ: Some(PortTypeEnum::TCP),
+                ..Default::default()
+            },
+            Port {
+                private_port: 22,
+                public_port: None,
+                typ: Some(PortTypeEnum::TCP),
+                ..Default::default()
+            },
+            Port {
+                private_port: 53,
+                public_port: Some(53),
+                typ: None,
+                ..Default::default()
+            },
+            Port {
+                private_port: 443,
+                public_port: Some(443),
+                typ: Some(PortTypeEnum::TCP),
+                ..Default::default()
+            },
+            Port {
+                private_port: 8080,
+                public_port: Some(80),
+                typ: Some(PortTypeEnum::TCP),
+                ..Default::default()
+            },
+        ];
+
+        let mappings = PortMapping::from_summary_ports(&ports);
+        assert_eq!(mappings.len(), 2);
+        assert_eq!(mappings[0].private, 443);
+        assert_eq!(mappings[1].private, 8080);
+        assert_eq!(mappings[1].to_string(), "8080:80/tcp");
+    }
+
+    #[test]
+    fn port_config_from_port_map_handles_ipv4_only() {
+        let mut ports = HashMap::new();
+        ports.insert(
+            "80/tcp".to_string(),
+            Some(vec![PortBinding {
+                host_ip: Some("0.0.0.0".to_string()),
+                host_port: Some("8080".to_string()),
+            }]),
+        );
+
+        let configs = PortConfig::from_port_map(&ports);
+        assert_eq!(configs.len(), 1);
+        assert_eq!(configs[0].to_string(), "0.0.0.0:8080 -> 80/tcp");
+    }
+
+    #[test]
+    fn port_config_from_port_map_handles_ipv6_only() {
+        let mut ports = HashMap::new();
+        ports.insert(
+            "80/tcp".to_string(),
+            Some(vec![PortBinding {
+                host_ip: Some("::".to_string()),
+                host_port: Some("8080".to_string()),
+            }]),
+        );
+
+        let configs = PortConfig::from_port_map(&ports);
+        assert_eq!(configs.len(), 1);
+        assert_eq!(configs[0].to_string(), ":::8080 -> 80/tcp");
+    }
+
+    #[test]
+    fn port_config_from_port_map_handles_both() {
+        let mut ports = HashMap::new();
+        ports.insert(
+            "80/tcp".to_string(),
+            Some(vec![
+                PortBinding {
+                    host_ip: Some("0.0.0.0".to_string()),
+                    host_port: Some("8080".to_string()),
+                },
+                PortBinding {
+                    host_ip: Some("::".to_string()),
+                    host_port: Some("8080".to_string()),
+                },
+            ]),
+        );
+
+        let configs = PortConfig::from_port_map(&ports);
+        assert_eq!(configs.len(), 1);
+        let text = configs[0].to_string();
+        assert!(text.contains(" | "));
+        assert!(text.ends_with(" -> 80/tcp"));
+    }
+
+    #[test]
+    fn port_config_from_port_map_skips_missing_bindings() {
+        let mut ports = HashMap::new();
+        ports.insert("80/tcp".to_string(), None);
+        ports.insert("80".to_string(), Some(vec![]));
+
+        let configs = PortConfig::from_port_map(&ports);
+        assert!(configs.is_empty());
+    }
+
+    #[test]
+    fn port_config_from_port_map_handles_key_without_slash() {
+        let mut ports = HashMap::new();
+        ports.insert(
+            "80".to_string(),
+            Some(vec![PortBinding {
+                host_ip: Some("0.0.0.0".to_string()),
+                host_port: Some("8080".to_string()),
+            }]),
+        );
+
+        let configs = PortConfig::from_port_map(&ports);
+        assert_eq!(configs.len(), 1);
+        assert_eq!(configs[0].protocol, "");
+        assert_eq!(configs[0].container_port, "80");
+    }
+
+    #[test]
+    fn mount_from_mount_points_selects_source_by_type() {
+        let mount_points = vec![
+            MountPoint {
+                typ: Some(MountPointTypeEnum::VOLUME),
+                name: Some("my-volume".to_string()),
+                source: Some("/var/lib/docker/volumes/my-volume".to_string()),
+                destination: Some("/data".to_string()),
+                ..Default::default()
+            },
+            MountPoint {
+                typ: Some(MountPointTypeEnum::BIND),
+                name: None,
+                source: Some("/host/path".to_string()),
+                destination: Some("/container/path".to_string()),
+                ..Default::default()
+            },
+            MountPoint {
+                typ: None,
+                name: None,
+                source: None,
+                destination: None,
+                ..Default::default()
+            },
+        ];
+
+        let mounts = Mount::from_mount_points(&mount_points);
+        assert_eq!(mounts[0].source, "my-volume");
+        assert_eq!(mounts[0].destination, "/data");
+        assert_eq!(mounts[1].source, "/host/path");
+        assert_eq!(mounts[1].destination, "/container/path");
+        assert_eq!(mounts[2].source, "-");
+        assert_eq!(mounts[2].destination, "-");
+    }
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -57,6 +57,14 @@ impl EventHandler {
     pub fn send(&mut self, app_event: AppEvent) {
         let _ = self.sender.send(Event::App(app_event));
     }
+
+    /// Test-only constructor; skips the crossterm reader task so `App` can be driven
+    /// deterministically without a terminal.
+    #[cfg(test)]
+    pub fn new_without_reader() -> Self {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        Self { sender, receiver }
+    }
 }
 
 struct EventTask {
@@ -94,5 +102,20 @@ impl EventTask {
 
     fn send(&self, event: Event) {
         let _ = self.sender.send(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn send_then_next_returns_the_app_event() {
+        let mut handler = EventHandler::new_without_reader();
+
+        handler.send(AppEvent::Quit);
+
+        let event = handler.next().await.unwrap();
+        assert!(matches!(event, Event::App(AppEvent::Quit)));
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -4,18 +4,20 @@ use bollard::secret::{
 use color_eyre::eyre::{OptionExt, Result};
 use crossterm::event::KeyEventKind;
 use futures::{FutureExt, StreamExt};
-use ratatui::crossterm::event::{Event::Key, KeyEvent};
+use ratatui::crossterm::event::{Event::Key, Event::Resize, KeyEvent};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
 use crate::docker::error::DockerResult;
 
-const TICK_FPS: f64 = 30.0;
+/// Ticks now only drive Docker refresh scheduling, not rendering.
+const TICK_FPS: f64 = 5.0;
 
 #[derive(Clone, Debug)]
 pub enum Event {
     Tick,
     Crossterm(KeyEvent),
+    Resize,
     App(AppEvent),
     Docker(DockerOutcome),
 }
@@ -130,10 +132,8 @@ impl EventTask {
                 _ = self.sender.closed() => break,
                 _ = tick_delay => self.send(Event::Tick),
                 Some(Ok(event)) = crossterm_event => {
-                    if let Key(key) = event
-                        && key.kind == KeyEventKind::Press
-                    {
-                        self.send(Event::Crossterm(key))
+                    if let Some(event) = map_crossterm_event(event) {
+                        self.send(event)
                     }
                 }
             };
@@ -144,6 +144,17 @@ impl EventTask {
 
     fn send(&self, event: Event) {
         let _ = self.sender.send(event);
+    }
+}
+
+/// Maps a raw crossterm event to the subset of `Event`s the app cares about.
+/// Only key-press events and terminal resizes are forwarded; everything else
+/// (key release/repeat, mouse, focus, paste) is discarded.
+fn map_crossterm_event(event: crossterm::event::Event) -> Option<Event> {
+    match event {
+        Key(key) if key.kind == KeyEventKind::Press => Some(Event::Crossterm(key)),
+        Resize(..) => Some(Event::Resize),
+        _ => None,
     }
 }
 
@@ -159,6 +170,29 @@ mod tests {
 
         let event = handler.next().await.unwrap();
         assert!(matches!(event, Event::App(AppEvent::Quit)));
+    }
+
+    #[test]
+    fn map_crossterm_event_forwards_key_press_and_resize_only() {
+        use crossterm::event::{KeyCode, KeyModifiers};
+
+        let key_press =
+            crossterm::event::Event::Key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
+        assert!(matches!(
+            map_crossterm_event(key_press),
+            Some(Event::Crossterm(_))
+        ));
+
+        let mut key_release = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
+        key_release.kind = KeyEventKind::Release;
+        assert!(map_crossterm_event(Key(key_release)).is_none());
+
+        assert!(matches!(
+            map_crossterm_event(Resize(80, 24)),
+            Some(Event::Resize)
+        ));
+
+        assert!(map_crossterm_event(crossterm::event::Event::FocusGained).is_none());
     }
 
     #[tokio::test]

--- a/src/event.rs
+++ b/src/event.rs
@@ -78,10 +78,10 @@ impl EventTask {
                 _ = self.sender.closed() => break,
                 _ = tick_delay => self.send(Event::Tick),
                 Some(Ok(event)) = crossterm_event => {
-                    if let Key(key) = event {
-                        if key.kind == KeyEventKind::Press {
-                            self.send(Event::Crossterm(key))
-                        }
+                    if let Key(key) = event
+                        && key.kind == KeyEventKind::Press
+                    {
+                        self.send(Event::Crossterm(key))
                     }
                 }
             };

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,9 +1,14 @@
+use bollard::secret::{
+    ContainerInspectResponse, ContainerSummary, ImageSummary, Network, VolumeListResponse,
+};
 use color_eyre::eyre::{OptionExt, Result};
 use crossterm::event::KeyEventKind;
 use futures::{FutureExt, StreamExt};
 use ratatui::crossterm::event::{Event::Key, KeyEvent};
 use std::time::Duration;
 use tokio::sync::mpsc;
+
+use crate::docker::error::DockerResult;
 
 const TICK_FPS: f64 = 30.0;
 
@@ -12,6 +17,7 @@ pub enum Event {
     Tick,
     Crossterm(KeyEvent),
     App(AppEvent),
+    Docker(DockerOutcome),
 }
 
 #[derive(Clone, Debug)]
@@ -31,6 +37,32 @@ pub enum AppEvent {
     UpdateImages,
     RemoveImage(String, bool),
     Back,
+}
+
+/// Outcome of a background Docker operation, delivered back through the event channel
+/// once the spawned task that ran it completes.
+#[derive(Clone, Debug)]
+pub enum DockerOutcome {
+    ContainersListed(DockerResult<Vec<ContainerSummary>>),
+    VolumesListed(DockerResult<VolumeListResponse>),
+    NetworksListed(DockerResult<Vec<Network>>),
+    ImagesListed(DockerResult<Vec<ImageSummary>>),
+    ContainerInspected {
+        open_details: bool,
+        result: DockerResult<Box<ContainerInspectResponse>>,
+    },
+    ActionCompleted {
+        resource: ResourceKind,
+        result: DockerResult<()>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResourceKind {
+    Containers,
+    Volumes,
+    Networks,
+    Images,
 }
 
 #[derive(Debug)]
@@ -58,12 +90,22 @@ impl EventHandler {
         let _ = self.sender.send(Event::App(app_event));
     }
 
+    /// Clone of the event channel sender, for background tasks that report Docker results.
+    pub fn sender(&self) -> mpsc::UnboundedSender<Event> {
+        self.sender.clone()
+    }
+
     /// Test-only constructor; skips the crossterm reader task so `App` can be driven
     /// deterministically without a terminal.
     #[cfg(test)]
     pub fn new_without_reader() -> Self {
         let (sender, receiver) = mpsc::unbounded_channel();
         Self { sender, receiver }
+    }
+
+    #[cfg(test)]
+    pub fn try_next(&mut self) -> Option<Event> {
+        self.receiver.try_recv().ok()
     }
 }
 
@@ -117,5 +159,27 @@ mod tests {
 
         let event = handler.next().await.unwrap();
         assert!(matches!(event, Event::App(AppEvent::Quit)));
+    }
+
+    #[tokio::test]
+    async fn docker_outcome_is_delivered_through_the_sender_clone() {
+        let mut handler = EventHandler::new_without_reader();
+        let sender = handler.sender();
+
+        sender
+            .send(Event::Docker(DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Containers,
+                result: Ok(()),
+            }))
+            .unwrap();
+
+        let event = handler.next().await.unwrap();
+        assert!(matches!(
+            event,
+            Event::Docker(DockerOutcome::ActionCompleted {
+                resource: ResourceKind::Containers,
+                result: Ok(())
+            })
+        ));
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,7 +1,7 @@
 use color_eyre::eyre::{OptionExt, Result};
 use crossterm::event::KeyEventKind;
 use futures::{FutureExt, StreamExt};
-use ratatui::crossterm::event::{KeyEvent, Event::Key};
+use ratatui::crossterm::event::{Event::Key, KeyEvent};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
@@ -48,7 +48,9 @@ impl EventHandler {
     }
 
     pub async fn next(&mut self) -> Result<Event> {
-        self.receiver.recv().await
+        self.receiver
+            .recv()
+            .await
             .ok_or_eyre("Failed to receive event")
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,10 @@ use color_eyre::eyre::Result;
 async fn main() -> Result<()> {
     color_eyre::install()?;
     let terminal = ratatui::init();
-    let app = App::new()?;
-    let result = app.run(terminal).await;
+    let result = match App::new() {
+        Ok(app) => app.run(terminal).await,
+        Err(e) => Err(e),
+    };
     ratatui::restore();
     result
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod app;
-mod ui;
 mod docker;
 mod event;
+mod ui;
 mod utils;
 
 use crate::app::App;

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -6,7 +6,7 @@ use ratatui::{
 };
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const REFRESH_AFTER_TICK: u8 = 10;
+const REFRESH_EVERY_TICKS: u8 = 2;
 
 #[derive(Default, Clone)]
 pub struct RefreshTicker {
@@ -14,14 +14,16 @@ pub struct RefreshTicker {
 }
 
 impl RefreshTicker {
-    /// Returns true once every `REFRESH_AFTER_TICK + 2` ticks, resetting the counter.
+    /// Returns true once every `REFRESH_EVERY_TICKS` ticks, resetting the counter.
+    /// At `TICK_FPS = 5.0` that is every 400 ms, matching the previous cadence of
+    /// every 12 ticks at 30 FPS.
     pub fn should_refresh(&mut self) -> bool {
-        if self.skipped_tick_count <= REFRESH_AFTER_TICK {
-            self.skipped_tick_count += 1;
-            false
-        } else {
+        self.skipped_tick_count += 1;
+        if self.skipped_tick_count >= REFRESH_EVERY_TICKS {
             self.skipped_tick_count = 0;
             true
+        } else {
+            false
         }
     }
 }
@@ -143,17 +145,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn refresh_ticker_fires_every_twelfth_tick() {
+    fn refresh_ticker_fires_every_second_tick() {
         let mut ticker = RefreshTicker::default();
 
-        for _ in 0..11 {
-            assert!(!ticker.should_refresh());
-        }
+        assert!(!ticker.should_refresh());
         assert!(ticker.should_refresh());
 
-        for _ in 0..11 {
-            assert!(!ticker.should_refresh());
-        }
+        assert!(!ticker.should_refresh());
         assert!(ticker.should_refresh());
     }
 

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -109,7 +109,11 @@ pub fn time_ago_string(epoch_secs: i64) -> String {
         .as_secs() as i64;
 
     let diff = now - epoch_secs;
-    let abs_diff = diff.abs();
+    format_time_ago(diff)
+}
+
+fn format_time_ago(diff_secs: i64) -> String {
+    let abs_diff = diff_secs.abs();
 
     let (value, unit) = if abs_diff >= 31_536_000 {
         (abs_diff / 31_536_000, "year")
@@ -127,7 +131,7 @@ pub fn time_ago_string(epoch_secs: i64) -> String {
 
     let plural = if value == 1 { "" } else { "s" };
 
-    if diff >= 0 {
+    if diff_secs >= 0 {
         format!("{value} {unit}{plural} ago")
     } else {
         format!("in {value} {unit}{plural}")
@@ -151,5 +155,40 @@ mod tests {
             assert!(!ticker.should_refresh());
         }
         assert!(ticker.should_refresh());
+    }
+
+    #[test]
+    fn format_time_ago_unit_boundaries() {
+        assert_eq!(format_time_ago(59), "59 seconds ago");
+        assert_eq!(format_time_ago(60), "1 minute ago");
+        assert_eq!(format_time_ago(3_600), "1 hour ago");
+        assert_eq!(format_time_ago(86_400), "1 day ago");
+        assert_eq!(format_time_ago(2_592_000), "1 month ago");
+        assert_eq!(format_time_ago(31_536_000), "1 year ago");
+    }
+
+    #[test]
+    fn format_time_ago_plural_vs_singular() {
+        assert_eq!(format_time_ago(120), "2 minutes ago");
+    }
+
+    #[test]
+    fn format_time_ago_zero_diff() {
+        assert_eq!(format_time_ago(0), "0 seconds ago");
+    }
+
+    #[test]
+    fn format_time_ago_negative_diff_is_in_the_future() {
+        assert_eq!(format_time_ago(-300), "in 5 minutes");
+    }
+
+    #[test]
+    fn time_ago_string_smoke_test_for_now() {
+        let now_epoch = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs() as i64;
+
+        assert!(time_ago_string(now_epoch).starts_with("0 second"));
     }
 }

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -6,6 +6,26 @@ use ratatui::{
 };
 use std::time::{SystemTime, UNIX_EPOCH};
 
+const REFRESH_AFTER_TICK: u8 = 10;
+
+#[derive(Default, Clone)]
+pub struct RefreshTicker {
+    skipped_tick_count: u8,
+}
+
+impl RefreshTicker {
+    /// Returns true once every `REFRESH_AFTER_TICK + 2` ticks, resetting the counter.
+    pub fn should_refresh(&mut self) -> bool {
+        if self.skipped_tick_count <= REFRESH_AFTER_TICK {
+            self.skipped_tick_count += 1;
+            false
+        } else {
+            self.skipped_tick_count = 0;
+            true
+        }
+    }
+}
+
 pub struct TableStyle {
     pub header_style: Style,
     pub selected_row_style: Style,
@@ -33,11 +53,28 @@ impl Default for TableStyle {
     }
 }
 
-pub fn render_scrollbar(frame: &mut Frame, area: Rect, state: &mut ScrollbarState, is_vertical: bool) {
+pub fn render_scrollbar(
+    frame: &mut Frame,
+    area: Rect,
+    state: &mut ScrollbarState,
+    is_vertical: bool,
+) {
     let (orientation, begin_symbol, end_symbol, track_symbol, thumb_symbol) = if is_vertical {
-        (ScrollbarOrientation::VerticalRight, Some("^"), Some("v"), Some("│"), "█")
+        (
+            ScrollbarOrientation::VerticalRight,
+            Some("^"),
+            Some("v"),
+            Some("│"),
+            "█",
+        )
     } else {
-        (ScrollbarOrientation::HorizontalBottom, Some("<"), Some(">"), Some("─"), "■")
+        (
+            ScrollbarOrientation::HorizontalBottom,
+            Some("<"),
+            Some(">"),
+            Some("─"),
+            "■",
+        )
     };
 
     let scrollbar = Scrollbar::new(orientation)
@@ -94,5 +131,25 @@ pub fn time_ago_string(epoch_secs: i64) -> String {
         format!("{value} {unit}{plural} ago")
     } else {
         format!("in {value} {unit}{plural}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refresh_ticker_fires_every_twelfth_tick() {
+        let mut ticker = RefreshTicker::default();
+
+        for _ in 0..11 {
+            assert!(!ticker.should_refresh());
+        }
+        assert!(ticker.should_refresh());
+
+        for _ in 0..11 {
+            assert!(!ticker.should_refresh());
+        }
+        assert!(ticker.should_refresh());
     }
 }

--- a/src/ui/container_info_block.rs
+++ b/src/ui/container_info_block.rs
@@ -431,4 +431,157 @@ mod tests {
         assert!(!lines.iter().any(|l| l.starts_with("Env:")));
         assert!(!lines.iter().any(|l| l.starts_with("Labels:")));
     }
+
+    #[test]
+    fn format_list_returns_none_for_empty_or_blank_entries() {
+        assert!(format_list(vec![]).is_none());
+        assert!(format_list(vec!["".to_string(), "".to_string()]).is_none());
+    }
+
+    #[test]
+    fn format_list_sorts_and_prefixes_entries() {
+        let result = format_list(vec!["charlie".to_string(), "alpha".to_string()]).unwrap();
+        let contents: Vec<String> = result.into_iter().map(|(_, c)| c).collect();
+        assert_eq!(
+            contents,
+            vec![" - alpha".to_string(), " - charlie".to_string()]
+        );
+    }
+
+    #[test]
+    fn get_footer_text_variants() {
+        let running_text = get_footer_text(true);
+        assert!(running_text.contains("<R> restart | <S> stop | <X> kill"));
+        assert!(running_text.contains("<Del/D> remove"));
+
+        let stopped_text = get_footer_text(false);
+        assert!(stopped_text.contains("<R> start"));
+        assert!(stopped_text.contains("<Del/D> remove"));
+    }
+
+    fn container_with_id(id: &str) -> ContainerInspectResponse {
+        ContainerInspectResponse {
+            id: Some(id.to_string()),
+            name: Some(format!("/{id}")),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn handle_key_event_dispatches_resource_actions() {
+        let mut block = ContainerInfoBlock {
+            data: ContainerData::from(container_with_id("container-id")),
+            ..Default::default()
+        };
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Char('d')))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::RemoveContainer(id)) if id == "container-id"));
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Delete))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::RemoveContainer(id)) if id == "container-id"));
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Char('r')))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::RestartContainer(id)) if id == "container-id"));
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Char('s')))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::StopContainer(id)) if id == "container-id"));
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Char('x')))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::KillContainer(id)) if id == "container-id"));
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Char('q')))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::Back)));
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Esc))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::Back)));
+    }
+
+    #[test]
+    fn tick_fires_exactly_once_every_twelve_ticks() {
+        let mut block = ContainerInfoBlock {
+            data: ContainerData::from(container_with_id("container-id")),
+            ..Default::default()
+        };
+
+        let mut fired = 0;
+        for _ in 0..12 {
+            if block.tick().unwrap().is_some() {
+                fired += 1;
+            }
+        }
+
+        assert_eq!(fired, 1);
+    }
+
+    #[test]
+    fn get_content_as_lines_includes_populated_sections_sorted() {
+        let container = ContainerInspectResponse {
+            id: Some("container-id".to_string()),
+            name: Some("/my-container".to_string()),
+            mounts: Some(vec![bollard::secret::MountPoint {
+                typ: Some(bollard::secret::MountPointTypeEnum::VOLUME),
+                name: Some("my-volume".to_string()),
+                destination: Some("/data".to_string()),
+                ..Default::default()
+            }]),
+            config: Some(ContainerConfig {
+                env: Some(vec!["B=2".to_string(), "A=1".to_string()]),
+                labels: Some({
+                    let mut labels = HashMap::new();
+                    labels.insert("z".to_string(), "last".to_string());
+                    labels.insert("a".to_string(), "first".to_string());
+                    labels
+                }),
+                ..Default::default()
+            }),
+            network_settings: Some(bollard::secret::NetworkSettings {
+                ports: Some({
+                    let mut ports = HashMap::new();
+                    ports.insert(
+                        "80/tcp".to_string(),
+                        Some(vec![bollard::secret::PortBinding {
+                            host_ip: Some("0.0.0.0".to_string()),
+                            host_port: Some("8080".to_string()),
+                        }]),
+                    );
+                    ports
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let data = ContainerData::from(container);
+        let lines: Vec<String> = get_content_as_lines(&data)
+            .iter()
+            .map(|l| l.to_string())
+            .collect();
+
+        assert!(lines.iter().any(|l| l.starts_with("Port Configs:")));
+        assert!(lines.iter().any(|l| l.starts_with("Volumes:")));
+        assert!(lines.iter().any(|l| l.starts_with("Env:")));
+        assert!(lines.iter().any(|l| l.starts_with("Labels:")));
+
+        let env_index = lines.iter().position(|l| l.starts_with("Env:")).unwrap();
+        assert!(lines[env_index + 1].contains("A=1"));
+        assert!(lines[env_index + 2].contains("B=2"));
+
+        let labels_index = lines.iter().position(|l| l.starts_with("Labels:")).unwrap();
+        assert!(lines[labels_index + 1].contains("a: first"));
+        assert!(lines[labels_index + 2].contains("z: last"));
+    }
 }

--- a/src/ui/container_info_block.rs
+++ b/src/ui/container_info_block.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use crate::docker::models::{Mount, PortConfig};
 use crate::{event::AppEvent, utils::is_container_running};
 
-use super::common::{render_footer, render_scrollbar};
+use super::common::{RefreshTicker, render_footer, render_scrollbar};
 use bollard::secret::{ContainerInspectResponse, ContainerStateStatusEnum};
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
@@ -21,7 +21,7 @@ use super::info_block::{ScrollInfo, ScrollableInfoBlock};
 pub struct ContainerInfoBlock {
     data: ContainerData,
     scroll_info: ScrollInfo,
-    skipped_tick_count_for_refresh: u8,
+    ticker: RefreshTicker,
 }
 
 #[derive(Clone)]
@@ -140,11 +140,9 @@ impl ScrollableInfoBlock for ContainerInfoBlock {
     }
 
     fn tick(&mut self) -> Result<Option<AppEvent>> {
-        let event = if self.skipped_tick_count_for_refresh > 10 {
-            self.skipped_tick_count_for_refresh = 0;
+        let event = if self.ticker.should_refresh() {
             Some(AppEvent::UpdateContainerInfo(self.data.id.clone()))
         } else {
-            self.skipped_tick_count_for_refresh += 1;
             None
         };
         Ok(event)

--- a/src/ui/container_info_block.rs
+++ b/src/ui/container_info_block.rs
@@ -1,11 +1,10 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
+use crate::docker::models::{Mount, PortConfig};
 use crate::{event::AppEvent, utils::is_container_running};
 
 use super::common::{render_footer, render_scrollbar};
-use bollard::secret::{
-    ContainerInspectResponse, ContainerStateStatusEnum, MountPoint, MountPointTypeEnum, PortBinding,
-};
+use bollard::secret::{ContainerInspectResponse, ContainerStateStatusEnum};
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
@@ -25,22 +24,43 @@ pub struct ContainerInfoBlock {
     skipped_tick_count_for_refresh: u8,
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct ContainerData {
     id: String,
     name: String,
     image: String,
     created: String,
-    state: String,
+    state: ContainerStateStatusEnum,
     ip_address: String,
     start_time: String,
-    port_configs: String,
-    cmd: String,
-    entrypoint: String,
-    env: String,
+    port_configs: Vec<PortConfig>,
+    cmd: Vec<String>,
+    entrypoint: Vec<String>,
+    env: Vec<String>,
     restart_policy: String,
-    volumes: String,
-    labels: String,
+    volumes: Vec<Mount>,
+    labels: BTreeMap<String, String>,
+}
+
+impl Default for ContainerData {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            name: String::new(),
+            image: String::new(),
+            created: String::new(),
+            state: ContainerStateStatusEnum::EMPTY,
+            ip_address: String::new(),
+            start_time: String::new(),
+            port_configs: Vec::new(),
+            cmd: Vec::new(),
+            entrypoint: Vec::new(),
+            env: Vec::new(),
+            restart_policy: String::new(),
+            volumes: Vec::new(),
+            labels: BTreeMap::new(),
+        }
+    }
 }
 
 impl ScrollableInfoBlock for ContainerInfoBlock {
@@ -75,12 +95,17 @@ impl ScrollableInfoBlock for ContainerInfoBlock {
             if line_len > max { line_len } else { max }
         });
 
-        self.scroll_info.max_horizontal = max_horizontal.saturating_sub(info_area.width as usize - 2);
-        self.scroll_info.max_vertical = content_lines.len().saturating_sub(info_area.height as usize - 2);
+        self.scroll_info.max_horizontal =
+            max_horizontal.saturating_sub(info_area.width as usize - 2);
+        self.scroll_info.max_vertical = content_lines
+            .len()
+            .saturating_sub(info_area.height as usize - 2);
 
         self.render_content(frame, info_area, content_lines);
 
-        self.scroll_info.vertical_state = self.scroll_info.vertical_state
+        self.scroll_info.vertical_state = self
+            .scroll_info
+            .vertical_state
             .content_length(self.scroll_info.max_vertical)
             .position(self.scroll_info.vertical);
 
@@ -91,7 +116,9 @@ impl ScrollableInfoBlock for ContainerInfoBlock {
             true,
         );
 
-        self.scroll_info.horizontal_state = self.scroll_info.horizontal_state
+        self.scroll_info.horizontal_state = self
+            .scroll_info
+            .horizontal_state
             .content_length(self.scroll_info.max_horizontal)
             .position(self.scroll_info.horizontal);
 
@@ -105,7 +132,7 @@ impl ScrollableInfoBlock for ContainerInfoBlock {
         render_footer(
             frame,
             footer_area,
-            get_footer_text(is_container_running(&self.data.state)),
+            get_footer_text(is_container_running(self.data.state)),
             None,
         );
 
@@ -165,10 +192,24 @@ fn get_content_as_lines(data: &ContainerData) -> Vec<Line<'static>> {
         ("Created: ".to_string(), data.created.clone()),
         ("Start Time: ".to_string(), data.start_time.clone()),
         ("Restart Policy: ".to_string(), data.restart_policy.clone()),
-        ("State: ".to_string(), data.state.clone()),
+        ("State: ".to_string(), data.state.to_string()),
         spacer.clone(),
-        ("CMD: ".to_string(), data.cmd.clone()),
-        ("Entrypoint: ".to_string(), data.entrypoint.clone()),
+        (
+            "CMD: ".to_string(),
+            if data.cmd.is_empty() {
+                "-".to_string()
+            } else {
+                data.cmd.join("\n")
+            },
+        ),
+        (
+            "Entrypoint: ".to_string(),
+            if data.entrypoint.is_empty() {
+                "-".to_string()
+            } else {
+                data.entrypoint.join("\n")
+            },
+        ),
     ];
 
     if !data.ip_address.is_empty() {
@@ -178,7 +219,8 @@ fn get_content_as_lines(data: &ContainerData) -> Vec<Line<'static>> {
         ]);
     }
 
-    if let Some(ports) = get_filtered_list(&data.port_configs) {
+    let port_configs = data.port_configs.iter().map(ToString::to_string).collect();
+    if let Some(ports) = format_list(port_configs) {
         lines.extend(vec![
             spacer.clone(),
             ("Port Configs:".to_string(), "".to_string()),
@@ -186,7 +228,8 @@ fn get_content_as_lines(data: &ContainerData) -> Vec<Line<'static>> {
         lines.extend(ports);
     }
 
-    if let Some(volumes) = get_filtered_list(&data.volumes) {
+    let volumes = data.volumes.iter().map(ToString::to_string).collect();
+    if let Some(volumes) = format_list(volumes) {
         lines.extend(vec![
             spacer.clone(),
             ("Volumes:".to_string(), "".to_string()),
@@ -194,12 +237,17 @@ fn get_content_as_lines(data: &ContainerData) -> Vec<Line<'static>> {
         lines.extend(volumes);
     }
 
-    if let Some(env) = get_filtered_list(&data.env) {
+    if let Some(env) = format_list(data.env.clone()) {
         lines.extend(vec![spacer.clone(), ("Env:".to_string(), "".to_string())]);
         lines.extend(env);
     }
 
-    if let Some(labels) = get_filtered_list(&data.labels) {
+    let labels = data
+        .labels
+        .iter()
+        .map(|(k, v)| format!("{k}: {v}"))
+        .collect();
+    if let Some(labels) = format_list(labels) {
         lines.extend(vec![
             spacer.clone(),
             ("Labels:".to_string(), "".to_string()),
@@ -216,18 +264,20 @@ fn get_content_as_lines(data: &ContainerData) -> Vec<Line<'static>> {
         .collect()
 }
 
-fn get_filtered_list(data: &str) -> Option<Vec<(String, String)>> {
-    let mut splitted_data: Vec<String> = data.split("\n")
-        .filter(|p| !p.is_empty())
-        .map(|s| s.to_string())
-        .collect();
+fn format_list(mut entries: Vec<String>) -> Option<Vec<(String, String)>> {
+    entries.retain(|e| !e.is_empty());
 
-    if splitted_data.is_empty() {
+    if entries.is_empty() {
         return None;
     }
 
-    splitted_data.sort_unstable();
-    Some(splitted_data.iter().map(|d| ("".to_string(), format!(" - {d}"))).collect())
+    entries.sort_unstable();
+    Some(
+        entries
+            .iter()
+            .map(|d| ("".to_string(), format!(" - {d}")))
+            .collect(),
+    )
 }
 
 fn get_footer_text(is_running: bool) -> String {
@@ -241,52 +291,56 @@ fn get_footer_text(is_running: bool) -> String {
 
 impl ContainerData {
     pub fn from(container: ContainerInspectResponse) -> Self {
-        let name = container.name.as_deref()
+        let name = container
+            .name
+            .as_deref()
             .and_then(|name| name.strip_prefix("/"))
             .map(String::from)
             .unwrap_or_else(|| "NaN".to_string());
 
-        let restart_policy = container.host_config.as_ref()
+        let restart_policy = container
+            .host_config
+            .as_ref()
             .and_then(|c| c.restart_policy.as_ref())
             .and_then(|c| c.name)
             .map(|name| format!("{name:?}").to_lowercase().replace("_", "-"))
             .unwrap_or_else(|| "-".to_string());
 
         let mut image = "-".to_string();
-        let mut cmd = "-".to_string();
-        let mut env = "-".to_string();
-        let mut entrypoint = "-".to_string();
-        let mut labels = "-".to_string();
+        let mut cmd = Vec::new();
+        let mut env = Vec::new();
+        let mut entrypoint = Vec::new();
+        let mut labels = BTreeMap::new();
         if let Some(config) = container.config {
             image = config.image.unwrap_or(image);
-            cmd = config.cmd.map(|c| c.join("\n")).unwrap_or(cmd);
-            env = config.env.map(|e| e.join("\n")).unwrap_or(env);
-            entrypoint = config.entrypoint.map(|ep| ep.join("\n")).unwrap_or(entrypoint);
-            labels = config.labels.map(|l| {
-                l.iter()
-                    .map(|(v, d)| format!("{v}: {d}"))
-                    .collect::<Vec<String>>()
-                    .join("\n")
-            }).unwrap_or(labels)
+            cmd = config.cmd.unwrap_or_default();
+            env = config.env.unwrap_or_default();
+            entrypoint = config.entrypoint.unwrap_or_default();
+            labels = config.labels.unwrap_or_default().into_iter().collect();
         }
 
         let mut ip_address = "-".to_string();
-        let mut port_configs = "-".to_string();
+        let mut port_configs = Vec::new();
         if let Some(network_settings) = container.network_settings {
             ip_address = network_settings.ip_address.unwrap_or(ip_address);
-            port_configs = network_settings.ports
-                .map(|p| get_ports_text(&p))
-                .unwrap_or(port_configs);
+            port_configs = network_settings
+                .ports
+                .map(|p| PortConfig::from_port_map(&p))
+                .unwrap_or_default();
         }
 
-        let mut state = ContainerStateStatusEnum::EMPTY.to_string();
+        let mut state = ContainerStateStatusEnum::EMPTY;
         let mut start_time = "-".to_string();
         if let Some(state_info) = container.state {
-            state = state_info.status.map(|s| s.to_string()).unwrap_or(state);
+            state = state_info.status.unwrap_or(state);
             start_time = state_info.started_at.unwrap_or(start_time);
         }
 
-        let volumes = container.mounts.as_ref().map_or("-".to_string(), |mp| get_mounts_text(mp));
+        let volumes = container
+            .mounts
+            .as_deref()
+            .map(Mount::from_mount_points)
+            .unwrap_or_default();
 
         Self {
             id: container.id.as_deref().unwrap_or("-").to_string(),
@@ -307,58 +361,76 @@ impl ContainerData {
     }
 }
 
-fn get_ports_text(ports: &HashMap<String, Option<Vec<PortBinding>>>) -> String {
-    ports
-        .iter()
-        .map(|(port, bindings)| {
-            let (ipv4_binding, ipv6_binding) = bindings
-                .as_ref()
-                .map(|b| {
-                    let ipv4 = b.iter().find(|pb| pb.host_ip == Some("0.0.0.0".to_string()));
-                    let ipv6 = b.iter().find(|pb| pb.host_ip == Some("::".to_string()));
-                    (ipv4, ipv6)
-                })
-                .unwrap_or((None, None));
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bollard::secret::{ContainerConfig, ContainerState};
+    use std::collections::HashMap;
 
-            let port_number = port.split('/').next().unwrap_or("");
-            let protocol = port.split('/').nth(1).unwrap_or("");
+    #[test]
+    fn from_extracts_typed_state_and_preserves_order() {
+        let mut labels = HashMap::new();
+        labels.insert("com.example.owner".to_string(), "team-a".to_string());
 
-            let ipv4_str = ipv4_binding.map(get_port_binding_text).unwrap_or_default();
-            let ipv6_str = ipv6_binding.map(get_port_binding_text).unwrap_or_default();
+        let container = ContainerInspectResponse {
+            id: Some("abc123".to_string()),
+            name: Some("/my-container".to_string()),
+            config: Some(ContainerConfig {
+                image: Some("alpine".to_string()),
+                cmd: Some(vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "sleep 1".to_string(),
+                ]),
+                env: Some(vec!["A=1".to_string(), "B=2".to_string()]),
+                labels: Some(labels),
+                ..Default::default()
+            }),
+            state: Some(ContainerState {
+                status: Some(ContainerStateStatusEnum::RUNNING),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
 
-            match (ipv4_str.is_empty(), ipv6_str.is_empty()) {
-                (false, false) => format!("{ipv4_str} | {ipv6_str} -> {port_number}/{protocol}"),
-                (false, true) => format!("{ipv4_str} -> {port_number}/{protocol}"),
-                (true, false) => format!("{ipv6_str} -> {port_number}/{protocol}"),
-                _ => "".to_string(),
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
+        let data = ContainerData::from(container);
 
-fn get_port_binding_text(port_binding: &PortBinding) -> String {
-    format!(
-        "{}:{}",
-        port_binding.host_ip.as_deref().unwrap_or(""),
-        port_binding.host_port.as_deref().unwrap_or("")
-    )
-}
+        assert_eq!(data.state, ContainerStateStatusEnum::RUNNING);
+        assert_eq!(data.cmd, vec!["sh", "-c", "sleep 1"]);
+        assert_eq!(data.env, vec!["A=1", "B=2"]);
+        assert_eq!(
+            data.labels.get("com.example.owner"),
+            Some(&"team-a".to_string())
+        );
+    }
 
-fn get_mounts_text(mount_points: &[MountPoint]) -> String {
-    let mut mp = mount_points.iter()
-        .map(|mp| {
-            let source = match mp.typ {
-                Some(MountPointTypeEnum::VOLUME) => mp.name.clone().unwrap_or("-".to_string()),
-                Some(_) => mp.source.clone().unwrap_or("-".to_string()),
-                None => "-".to_string(),
-            };
+    #[test]
+    fn from_empty_inspect_yields_empty_collections() {
+        let data = ContainerData::from(ContainerInspectResponse::default());
 
-            let destination = mp.destination.clone().unwrap_or("-".to_string());
-            format!("{source} -> {destination}")
-        })
-        .collect::<Vec<String>>();
+        assert_eq!(data.state, ContainerStateStatusEnum::EMPTY);
+        assert!(data.cmd.is_empty());
+        assert!(data.entrypoint.is_empty());
+        assert!(data.env.is_empty());
+        assert!(data.labels.is_empty());
+        assert!(data.port_configs.is_empty());
+        assert!(data.volumes.is_empty());
+    }
 
-    mp.sort_by_key(|v| v.clone());
-    mp.join("\n")
+    #[test]
+    fn get_content_as_lines_drops_empty_optional_sections() {
+        let data = ContainerData::default();
+        let lines: Vec<String> = get_content_as_lines(&data)
+            .iter()
+            .map(|l| l.to_string())
+            .collect();
+
+        // CMD/Entrypoint are "-" when empty and must be filtered out entirely.
+        assert!(!lines.iter().any(|l| l.starts_with("CMD: ")));
+        assert!(!lines.iter().any(|l| l.starts_with("Entrypoint: ")));
+
+        // No optional sections should render when their data is empty.
+        assert!(!lines.iter().any(|l| l.starts_with("Env:")));
+        assert!(!lines.iter().any(|l| l.starts_with("Labels:")));
+    }
 }

--- a/src/ui/container_info_block.rs
+++ b/src/ui/container_info_block.rs
@@ -22,9 +22,11 @@ pub struct ContainerInfoBlock {
     data: ContainerData,
     scroll_info: ScrollInfo,
     ticker: RefreshTicker,
+    content_lines: Vec<Line<'static>>,
+    max_line_width: usize,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct ContainerData {
     id: String,
     name: String,
@@ -88,19 +90,15 @@ impl ScrollableInfoBlock for ContainerInfoBlock {
         let horizontal_layout = Layout::horizontal([Min(0), Length(1)]);
         let [info_area, vertical_scrollbar_area] = horizontal_layout.areas(content_area);
 
-        let content_lines = get_content_as_lines(&self.data);
-
-        let max_horizontal = content_lines.iter().fold(0, |max, line| {
-            let line_len = line.to_string().len();
-            if line_len > max { line_len } else { max }
-        });
-
-        self.scroll_info.max_horizontal =
-            max_horizontal.saturating_sub(info_area.width as usize - 2);
-        self.scroll_info.max_vertical = content_lines
+        self.scroll_info.max_horizontal = self
+            .max_line_width
+            .saturating_sub(info_area.width as usize - 2);
+        self.scroll_info.max_vertical = self
+            .content_lines
             .len()
             .saturating_sub(info_area.height as usize - 2);
 
+        let content_lines = self.content_lines.clone();
         self.render_content(frame, info_area, content_lines);
 
         self.scroll_info.vertical_state = self
@@ -148,8 +146,13 @@ impl ScrollableInfoBlock for ContainerInfoBlock {
         Ok(event)
     }
 
-    fn update_data(&mut self, data: Self::Data) {
+    fn update_data(&mut self, data: Self::Data) -> bool {
+        if self.data == data {
+            return false;
+        }
         self.data = data;
+        self.rebuild_content_cache();
+        true
     }
 
     fn get_scroll_info(&mut self) -> &mut super::info_block::ScrollInfo {
@@ -158,6 +161,14 @@ impl ScrollableInfoBlock for ContainerInfoBlock {
 }
 
 impl ContainerInfoBlock {
+    fn rebuild_content_cache(&mut self) {
+        self.content_lines = get_content_as_lines(&self.data);
+        self.max_line_width = self.content_lines.iter().fold(0, |max, line| {
+            let line_len = line.to_string().len();
+            if line_len > max { line_len } else { max }
+        });
+    }
+
     fn render_content(&mut self, frame: &mut Frame, area: Rect, lines: Vec<Line<'static>>) {
         let block_style = Style::new().fg(tailwind::BLUE.c400);
 
@@ -511,7 +522,7 @@ mod tests {
     }
 
     #[test]
-    fn tick_fires_exactly_once_every_twelve_ticks() {
+    fn tick_fires_once_every_two_ticks() {
         let mut block = ContainerInfoBlock {
             data: ContainerData::from(container_with_id("container-id")),
             ..Default::default()
@@ -524,7 +535,7 @@ mod tests {
             }
         }
 
-        assert_eq!(fired, 1);
+        assert_eq!(fired, 6);
     }
 
     #[test]
@@ -583,5 +594,50 @@ mod tests {
         let labels_index = lines.iter().position(|l| l.starts_with("Labels:")).unwrap();
         assert!(lines[labels_index + 1].contains("a: first"));
         assert!(lines[labels_index + 2].contains("z: last"));
+    }
+
+    #[test]
+    fn update_data_caches_lines_and_max_width() {
+        let mut block = ContainerInfoBlock::default();
+
+        let changed = block.update_data(ContainerData::from(container_with_id("abc")));
+        assert!(changed);
+
+        assert!(!block.content_lines.is_empty());
+        assert!(
+            block
+                .content_lines
+                .iter()
+                .any(|l| l.to_string().starts_with("ID: abc"))
+        );
+        assert_eq!(
+            block.max_line_width,
+            block
+                .content_lines
+                .iter()
+                .map(|l| l.to_string().len())
+                .max()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn update_data_with_identical_data_is_a_no_op() {
+        let mut block = ContainerInfoBlock::default();
+
+        let changed = block.update_data(ContainerData::from(container_with_id("abc")));
+        assert!(changed);
+
+        let changed_again = block.update_data(ContainerData::from(container_with_id("abc")));
+        assert!(!changed_again);
+
+        let changed_different = block.update_data(ContainerData::from(container_with_id("xyz")));
+        assert!(changed_different);
+        assert!(
+            block
+                .content_lines
+                .iter()
+                .any(|l| l.to_string().starts_with("ID: xyz"))
+        );
     }
 }

--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -106,14 +106,6 @@ impl ResourceTable for ContainerTable {
 
         Ok(outcome)
     }
-
-    fn error_message(&self, raw: &str) -> String {
-        raw.split(":")
-            .collect::<Vec<&str>>()
-            .get(2)
-            .map_or("Something went wrong...", |v| v)
-            .to_string()
-    }
 }
 
 impl ResourceRow for ContainerTableRow {
@@ -276,13 +268,6 @@ mod tests {
         let text = get_footer_text(false, Some(false));
         assert!(text.contains("<R> start"));
         assert!(text.contains("<T> Running"));
-    }
-
-    #[test]
-    fn error_message_extracts_third_colon_segment() {
-        let table = ContainerTable::default();
-        assert_eq!(table.error_message("a:b:message"), "message");
-        assert_eq!(table.error_message("a:b"), "Something went wrong...");
     }
 
     fn summary_with_ports(id: &str, state: &str) -> ContainerSummary {

--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -1,26 +1,19 @@
 use crate::docker::models::{PortMapping, parse_container_state, state_label};
-use crate::ui::resource_table::ResourceTableInfo;
-use crate::{event::AppEvent, ui::resource_table::ResourceTable, utils::is_container_running};
+use crate::ui::resource_table::{
+    DEFAULT_ROW_HEIGHT, KeyOutcome, ResourceRow, ResourceTable, ResourceTableInfo,
+};
+use crate::{event::AppEvent, utils::is_container_running};
 
-use super::common::{TableStyle, render_footer};
 use bollard::secret::{ContainerStateStatusEnum, ContainerSummary};
 use color_eyre::Result;
-use ratatui::style::Stylize;
 use ratatui::{
-    Frame,
     crossterm::event::{KeyCode, KeyEvent},
-    layout::{Constraint, Rect},
-    style::Style,
-    text::Text,
-    widgets::{Cell, HighlightSpacing, Row, Table},
+    layout::Constraint,
 };
 
 pub struct ContainerTable {
-    style: TableStyle,
     show_all: bool,
-    skipped_tick_count_for_update: u8,
     info: ResourceTableInfo<ContainerTableRow>,
-    err: Option<String>,
 }
 
 pub struct ContainerTableRow {
@@ -34,11 +27,8 @@ pub struct ContainerTableRow {
 impl Default for ContainerTable {
     fn default() -> Self {
         Self {
-            style: TableStyle::default(),
             show_all: true,
-            skipped_tick_count_for_update: 0,
             info: ResourceTableInfo::default(),
-            err: None,
         }
     }
 }
@@ -46,239 +36,90 @@ impl Default for ContainerTable {
 impl ResourceTable for ContainerTable {
     type RowType = ContainerTableRow;
 
-    fn get_table_info(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
+    const HEADERS: &'static [&'static str] = &["ID", "Name", "Image", "State", "Ports"];
+    const WIDTHS: &'static [Constraint] = &[
+        Constraint::Length(12),
+        Constraint::Percentage(20),
+        Constraint::Percentage(30),
+        Constraint::Percentage(10),
+        Constraint::Min(15),
+    ];
+    const DEFAULT_FOOTER: &'static str = "";
+
+    fn table_info(&self) -> &ResourceTableInfo<Self::RowType> {
+        &self.info
+    }
+
+    fn table_info_mut(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
         &mut self.info
     }
 
-    // The selection index refers to the rendered (filtered) rows, so it must be
-    // resolved and wrapped against the visible list, not `items`.
-    fn get_selected_row(&mut self) -> Option<&Self::RowType> {
-        let index = self.info.state.selected()?;
-        let item_index = *self.visible_indices().get(index)?;
-        self.info.items.get(item_index)
+    fn refresh_event(&self) -> AppEvent {
+        AppEvent::UpdateContainers
     }
 
-    fn next_row(&mut self) {
-        let Some(last_index) = self.visible_indices().len().checked_sub(1) else {
-            return;
-        };
-        let next_index = self
-            .info
-            .state
-            .selected()
-            .map_or(0, |i| if i >= last_index { 0 } else { i + 1 });
-        self.select_row(next_index);
+    fn is_row_visible(&self, row: &Self::RowType) -> bool {
+        self.show_all || is_container_running(row.state)
     }
 
-    fn previous_row(&mut self) {
-        let Some(last_index) = self.visible_indices().len().checked_sub(1) else {
-            return;
-        };
-        let previous_index = self
-            .info
-            .state
-            .selected()
-            .map_or(0, |i| if i == 0 { last_index } else { i - 1 });
-        self.select_row(previous_index);
+    fn footer_text(&self) -> String {
+        let is_selected_container_running =
+            self.selected_row().map(|c| is_container_running(c.state));
+        get_footer_text(self.show_all, is_selected_container_running)
     }
 
-    fn render_table(&mut self, frame: &mut Frame, area: Rect) {
-        let header = ["ID", "Name", "Image", "State", "Ports"]
-            .into_iter()
-            .map(Cell::from)
-            .collect::<Row>()
-            .style(self.style.header_style)
-            .height(1);
-
-        self.info.row_heights.clear();
-
-        let show_all = self.show_all;
-        let visible_items: Vec<&ContainerTableRow> = self
-            .info
-            .items
-            .iter()
-            .filter(|container| show_all || is_container_running(container.state))
-            .collect();
-        let visible_count = visible_items.len();
-
-        let rows = visible_items
-            .into_iter()
-            .enumerate()
-            .map(|(index, container)| {
-                let row_style = if index % 2 == 0 {
-                    self.style.row_style
-                } else {
-                    self.style.alt_row_style
-                };
-                let item = container.cells();
-                let port_count = container.ports.len();
-                let height = if port_count == 0 { 3 } else { port_count + 2 };
-                if index < visible_count - 1 {
-                    self.info.row_heights.push(height);
-                }
-
-                item.into_iter()
-                    .map(|content| Cell::from(Text::from(format!("\n{content}\n"))))
-                    .collect::<Row>()
-                    .style(row_style)
-                    .height(height as u16)
-            });
-
-        let widths = vec![
-            Constraint::Length(12),
-            Constraint::Percentage(20),
-            Constraint::Percentage(30),
-            Constraint::Percentage(10),
-            Constraint::Min(15),
-        ];
-
-        let table = Table::new(rows, widths)
-            .header(header)
-            .row_highlight_style(self.style.selected_row_style)
-            .highlight_symbol(Text::from(vec!["".into(), " ● ".into()]))
-            .highlight_spacing(HighlightSpacing::Always);
-
-        frame.render_stateful_widget(table, area, &mut self.info.state);
-    }
-
-    fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
-        let mut border_style = None;
-
-        let is_selected_container_running = self
-            .get_selected_row()
-            .map(|c| is_container_running(c.state));
-        let mut footer_text = get_footer_text(self.show_all, is_selected_container_running);
-
-        if let Some(err) = &self.err {
-            border_style = Some(Style::new().red());
-            footer_text = err.clone();
+    fn after_draw(&mut self) {
+        // If there is items but no row selected, select the first row.
+        // This happens when changing the `self.show_all` parameter.
+        if self.table_info().state.selected().is_none() && !self.visible_indices().is_empty() {
+            self.select_row(0);
         }
-
-        render_footer(frame, area, footer_text, border_style);
-    }
-}
-
-impl ContainerTable {
-    /// Indices into `info.items` for the rows that are currently visible.
-    /// Rendering, navigation and selection resolution all share this view.
-    fn visible_indices(&self) -> Vec<usize> {
-        self.info
-            .items
-            .iter()
-            .enumerate()
-            .filter(|(_, container)| self.show_all || is_container_running(container.state))
-            .map(|(index, _)| index)
-            .collect()
     }
 
-    pub fn handle_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
-        if self.err.is_some() {
-            self.err = None;
-            return Ok(None);
-        }
-
-        let event = match key_event.code {
+    fn handle_resource_key_event(&mut self, key_event: KeyEvent) -> Result<KeyOutcome> {
+        let outcome = match key_event.code {
             KeyCode::Char('t') => {
                 self.show_all = !self.show_all;
                 // The old selection index may point past the new visible list; clamp it.
                 if let Some(last_index) = self.visible_indices().len().checked_sub(1) {
-                    let selected = self.info.state.selected().unwrap_or(0);
+                    let selected = self.table_info().state.selected().unwrap_or(0);
                     self.select_row(selected.min(last_index));
                 }
-                None
+                KeyOutcome::Handled(None)
             }
-            KeyCode::Delete | KeyCode::Char('d') => self
-                .get_selected_row()
-                .map(|c| AppEvent::RemoveContainer(c.id.clone())),
-            KeyCode::Enter => self
-                .get_selected_row()
-                .map(|c| AppEvent::GoToContainerDetails(c.id.clone())),
-            KeyCode::Char(c) => match (c, self.get_selected_row().map(|c| c.id.clone())) {
-                ('r', Some(id)) => Some(AppEvent::RestartContainer(id)),
-                ('s', Some(id)) => Some(AppEvent::StopContainer(id)),
-                ('x', Some(id)) => Some(AppEvent::KillContainer(id)),
-                _ => self.handle_nav_key_event(key_event)?,
+            KeyCode::Delete | KeyCode::Char('d') => KeyOutcome::Handled(
+                self.selected_row()
+                    .map(|c| AppEvent::RemoveContainer(c.id.clone())),
+            ),
+            KeyCode::Enter => KeyOutcome::Handled(
+                self.selected_row()
+                    .map(|c| AppEvent::GoToContainerDetails(c.id.clone())),
+            ),
+            KeyCode::Char(c) => match (c, self.selected_row().map(|c| c.id.clone())) {
+                ('r', Some(id)) => KeyOutcome::Handled(Some(AppEvent::RestartContainer(id))),
+                ('s', Some(id)) => KeyOutcome::Handled(Some(AppEvent::StopContainer(id))),
+                ('x', Some(id)) => KeyOutcome::Handled(Some(AppEvent::KillContainer(id))),
+                _ => KeyOutcome::Fallthrough,
             },
-            _ => None,
+            _ => KeyOutcome::Handled(None),
         };
 
-        Ok(event)
+        Ok(outcome)
     }
 
-    pub fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        let result = self.draw_default(frame, area);
-
-        // If there is items but no row selected, select the first row.
-        // This happens when changing the `self.show_all` parameter.
-        if self.info.state.selected().is_none() && !self.visible_indices().is_empty() {
-            self.select_row(0);
-        }
-
-        result
-    }
-
-    pub fn tick(&mut self) -> Result<Option<AppEvent>> {
-        if self.skipped_tick_count_for_update <= 10 {
-            self.skipped_tick_count_for_update += 1;
-            return Ok(None);
-        }
-
-        self.skipped_tick_count_for_update = 0;
-        Ok(Some(AppEvent::UpdateContainers))
-    }
-
-    pub fn show_container_err(&mut self, err: String) {
-        let err_msg = err
-            .split(":")
+    fn error_message(&self, raw: &str) -> String {
+        raw.split(":")
             .collect::<Vec<&str>>()
             .get(2)
-            .map_or("Something went wrong...", |v| v);
-        self.err = Some(format!("[ERR] {}", err_msg.trim()))
+            .map_or("Something went wrong...", |v| v)
+            .to_string()
     }
 }
 
-impl ContainerTableRow {
-    fn cells(&self) -> [String; 5] {
-        let ports_text = if self.ports.is_empty() {
-            "-".to_string()
-        } else {
-            self.ports
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<String>>()
-                .join("\n")
-        };
+impl ResourceRow for ContainerTableRow {
+    type Source = ContainerSummary;
 
-        [
-            self.id.clone(),
-            self.name.clone(),
-            self.image.clone(),
-            state_label(self.state),
-            ports_text,
-        ]
-    }
-
-    pub fn from_list(containers: Vec<ContainerSummary>) -> Vec<Self> {
-        let mut result_list = containers
-            .iter()
-            .map(ContainerTableRow::from)
-            .collect::<Vec<ContainerTableRow>>();
-
-        result_list.sort_by(|p, n| {
-            let p_is_running = p.state == ContainerStateStatusEnum::RUNNING;
-            let n_is_running = n.state == ContainerStateStatusEnum::RUNNING;
-
-            match (p_is_running, n_is_running) {
-                (true, false) => std::cmp::Ordering::Less,
-                (false, true) => std::cmp::Ordering::Greater,
-                _ => p.state.as_ref().cmp(n.state.as_ref()),
-            }
-        });
-
-        result_list
-    }
-
-    fn from(container: &ContainerSummary) -> Self {
+    fn from_source(container: &Self::Source) -> Self {
         let name: String = container
             .names
             .as_deref()
@@ -297,6 +138,47 @@ impl ContainerTableRow {
                 .map(PortMapping::from_summary_ports)
                 .unwrap_or_default(),
         }
+    }
+
+    fn cells(&self) -> Vec<String> {
+        let ports_text = if self.ports.is_empty() {
+            "-".to_string()
+        } else {
+            self.ports
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<String>>()
+                .join("\n")
+        };
+
+        vec![
+            self.id.clone(),
+            self.name.clone(),
+            self.image.clone(),
+            state_label(self.state),
+            ports_text,
+        ]
+    }
+
+    fn height(&self) -> usize {
+        if self.ports.is_empty() {
+            DEFAULT_ROW_HEIGHT
+        } else {
+            self.ports.len() + 2
+        }
+    }
+
+    fn sort_rows(rows: &mut Vec<Self>) {
+        rows.sort_by(|p, n| {
+            let p_is_running = p.state == ContainerStateStatusEnum::RUNNING;
+            let n_is_running = n.state == ContainerStateStatusEnum::RUNNING;
+
+            match (p_is_running, n_is_running) {
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                _ => p.state.as_ref().cmp(n.state.as_ref()),
+            }
+        });
     }
 }
 
@@ -365,14 +247,14 @@ mod tests {
     #[test]
     fn from_strips_leading_slash_from_name() {
         let container = summary_with_state("running");
-        let row = ContainerTableRow::from(&container);
+        let row = ContainerTableRow::from_source(&container);
         assert_eq!(row.name, "running");
     }
 
     #[test]
     fn cells_fall_back_to_dash_for_missing_fields() {
         let container = ContainerSummary::default();
-        let row = ContainerTableRow::from(&container);
+        let row = ContainerTableRow::from_source(&container);
         let cells = row.cells();
 
         assert_eq!(cells[0], "-"); // id

--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -168,7 +168,13 @@ impl ResourceRow for ContainerTableRow {
             match (p_is_running, n_is_running) {
                 (true, false) => std::cmp::Ordering::Less,
                 (false, true) => std::cmp::Ordering::Greater,
-                _ => p.state.as_ref().cmp(n.state.as_ref()),
+                // Tie-break equal states by name so row order does not depend
+                // on the order the daemon returned the containers in.
+                _ => p
+                    .state
+                    .as_ref()
+                    .cmp(n.state.as_ref())
+                    .then_with(|| p.name.cmp(&n.name)),
             }
         });
     }
@@ -235,6 +241,27 @@ mod tests {
                 ContainerStateStatusEnum::RESTARTING,
             ]
         );
+    }
+
+    #[test]
+    fn from_list_breaks_equal_state_ties_by_name() {
+        let named = |name: &str| ContainerSummary {
+            id: Some(format!("id-{name}")),
+            names: Some(vec![format!("/{name}")]),
+            state: Some("exited".to_string()),
+            ..Default::default()
+        };
+
+        let names_of = |rows: &[ContainerTableRow]| -> Vec<String> {
+            rows.iter().map(|r| r.name.clone()).collect()
+        };
+
+        // Both input orders must yield the same on-screen order.
+        let one_way = ContainerTableRow::from_list(vec![named("bravo"), named("alpha")]);
+        let other_way = ContainerTableRow::from_list(vec![named("alpha"), named("bravo")]);
+
+        assert_eq!(names_of(&one_way), names_of(&other_way));
+        assert_eq!(names_of(&one_way), vec!["alpha", "bravo"]);
     }
 
     #[test]

--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -49,8 +49,41 @@ impl ResourceTable for ContainerTable {
         &mut self.info
     }
 
+    // The selection index refers to the rendered (filtered) rows, so it must be
+    // resolved and wrapped against the visible list, not `items`.
+    fn get_selected_row(&mut self) -> Option<&Self::RowType> {
+        let index = self.info.state.selected()?;
+        let item_index = *self.visible_indices().get(index)?;
+        self.info.items.get(item_index)
+    }
+
+    fn next_row(&mut self) {
+        let Some(last_index) = self.visible_indices().len().checked_sub(1) else {
+            return;
+        };
+        let next_index = self
+            .info
+            .state
+            .selected()
+            .map_or(0, |i| if i >= last_index { 0 } else { i + 1 });
+        self.select_row(next_index);
+    }
+
+    fn previous_row(&mut self) {
+        let Some(last_index) = self.visible_indices().len().checked_sub(1) else {
+            return;
+        };
+        let previous_index = self
+            .info
+            .state
+            .selected()
+            .map_or(0, |i| if i == 0 { last_index } else { i - 1 });
+        self.select_row(previous_index);
+    }
+
     fn render_table(&mut self, frame: &mut Frame, area: Rect) {
-        let header = ["ID", "Name", "Image", "State", "Ports"].into_iter()
+        let header = ["ID", "Name", "Image", "State", "Ports"]
+            .into_iter()
             .map(Cell::from)
             .collect::<Row>()
             .style(self.style.header_style)
@@ -58,15 +91,33 @@ impl ResourceTable for ContainerTable {
 
         self.info.row_heights.clear();
 
-        let rows = self.info.items.iter().enumerate()
-            .filter(|(_, container)| self.show_all || String::eq(&container.state, "running"))
+        let show_all = self.show_all;
+        let visible_items: Vec<&ContainerTableRow> = self
+            .info
+            .items
+            .iter()
+            .filter(|container| show_all || String::eq(&container.state, "running"))
+            .collect();
+        let visible_count = visible_items.len();
+
+        let rows = visible_items
+            .into_iter()
+            .enumerate()
             .map(|(index, container)| {
-                let row_style = if index % 2 == 0 { self.style.row_style } else { self.style.alt_row_style };
+                let row_style = if index % 2 == 0 {
+                    self.style.row_style
+                } else {
+                    self.style.alt_row_style
+                };
                 let item = container.ref_array();
-                let ports: Vec<&str> = container.ports.split("\n").filter(|s| !s.is_empty()).collect();
+                let ports: Vec<&str> = container
+                    .ports
+                    .split("\n")
+                    .filter(|s| !s.is_empty())
+                    .collect();
 
                 let height = if ports.is_empty() { 3 } else { ports.len() + 2 };
-                if index < self.info.items.len() - 1 {
+                if index < visible_count - 1 {
                     self.info.row_heights.push(height);
                 }
 
@@ -97,7 +148,9 @@ impl ResourceTable for ContainerTable {
     fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
         let mut border_style = None;
 
-        let is_selected_container_running = self.get_selected_row().map(|c| is_container_running(&c.state));
+        let is_selected_container_running = self
+            .get_selected_row()
+            .map(|c| is_container_running(&c.state));
         let mut footer_text = get_footer_text(self.show_all, is_selected_container_running);
 
         if let Some(err) = &self.err {
@@ -110,6 +163,18 @@ impl ResourceTable for ContainerTable {
 }
 
 impl ContainerTable {
+    /// Indices into `info.items` for the rows that are currently visible.
+    /// Rendering, navigation and selection resolution all share this view.
+    fn visible_indices(&self) -> Vec<usize> {
+        self.info
+            .items
+            .iter()
+            .enumerate()
+            .filter(|(_, container)| self.show_all || String::eq(&container.state, "running"))
+            .map(|(index, _)| index)
+            .collect()
+    }
+
     pub fn handle_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
         if self.err.is_some() {
             self.err = None;
@@ -119,10 +184,19 @@ impl ContainerTable {
         let event = match key_event.code {
             KeyCode::Char('t') => {
                 self.show_all = !self.show_all;
+                // The old selection index may point past the new visible list; clamp it.
+                if let Some(last_index) = self.visible_indices().len().checked_sub(1) {
+                    let selected = self.info.state.selected().unwrap_or(0);
+                    self.select_row(selected.min(last_index));
+                }
                 None
             }
-            KeyCode::Delete | KeyCode::Char('d') => self.get_selected_row().map(|c| AppEvent::RemoveContainer(c.id.clone())),
-            KeyCode::Enter => self.get_selected_row().map(|c| AppEvent::GoToContainerDetails(c.id.clone())),
+            KeyCode::Delete | KeyCode::Char('d') => self
+                .get_selected_row()
+                .map(|c| AppEvent::RemoveContainer(c.id.clone())),
+            KeyCode::Enter => self
+                .get_selected_row()
+                .map(|c| AppEvent::GoToContainerDetails(c.id.clone())),
             KeyCode::Char(c) => match (c, self.get_selected_row().map(|c| c.id.clone())) {
                 ('r', Some(id)) => Some(AppEvent::RestartContainer(id)),
                 ('s', Some(id)) => Some(AppEvent::StopContainer(id)),
@@ -140,7 +214,7 @@ impl ContainerTable {
 
         // If there is items but no row selected, select the first row.
         // This happens when changing the `self.show_all` parameter.
-        if self.info.state.selected().is_none() && !self.info.items.is_empty() {
+        if self.info.state.selected().is_none() && !self.visible_indices().is_empty() {
             self.select_row(0);
         }
 
@@ -158,7 +232,10 @@ impl ContainerTable {
     }
 
     pub fn show_container_err(&mut self, err: String) {
-        let err_msg = err.split(":") .collect::<Vec<&str>>().get(2)
+        let err_msg = err
+            .split(":")
+            .collect::<Vec<&str>>()
+            .get(2)
             .map_or("Something went wrong...", |v| v);
         self.err = Some(format!("[ERR] {}", err_msg.trim()))
     }
@@ -170,7 +247,8 @@ impl ContainerTableRow {
     }
 
     pub fn from_list(containers: Vec<ContainerSummary>) -> Vec<Self> {
-        let mut result_list = containers.iter()
+        let mut result_list = containers
+            .iter()
             .map(ContainerTableRow::from)
             .collect::<Vec<ContainerTableRow>>();
 
@@ -189,7 +267,9 @@ impl ContainerTableRow {
     }
 
     fn from(container: &ContainerSummary) -> Self {
-        let name: String = container.names.as_deref()
+        let name: String = container
+            .names
+            .as_deref()
             .and_then(|names| names.first())
             .and_then(|name| name.strip_prefix("/"))
             .map_or("NaN".to_string(), |name| name.to_string());
@@ -199,20 +279,25 @@ impl ContainerTableRow {
             name,
             image: container.image.as_deref().unwrap_or("-").to_string(),
             state: container.state.as_deref().unwrap_or("-").to_string(),
-            ports: container.ports.as_ref().map_or("-".to_string(), |p| get_ports_text(p)),
+            ports: container
+                .ports
+                .as_ref()
+                .map_or("-".to_string(), |p| get_ports_text(p)),
         }
     }
 }
 
 fn get_ports_text(ports: &[Port]) -> String {
-    let mut filtered_ports: Vec<(u16, u16, PortTypeEnum)> = ports.iter()
+    let mut filtered_ports: Vec<(u16, u16, PortTypeEnum)> = ports
+        .iter()
         .filter_map(|p| Some((p.private_port, p.public_port?, p.typ?)))
         .collect();
 
     filtered_ports.sort_by_key(|&(private, _, _)| private);
     filtered_ports.dedup();
 
-    filtered_ports.iter()
+    filtered_ports
+        .iter()
         .map(|&(private, public, typ)| format!("{private}:{public}/{typ}"))
         .collect::<Vec<String>>()
         .join("\n")
@@ -223,7 +308,11 @@ fn get_footer_text(show_all: bool, is_running: Option<bool>) -> String {
     let mut op_text = "".to_string();
 
     if let Some(running) = is_running {
-        let running_text = if running { "restart | <S> stop | <X> kill " } else { "start " };
+        let running_text = if running {
+            "restart | <S> stop | <X> kill "
+        } else {
+            "start "
+        };
         op_text = format!(" | <R> {running_text}| <Del/D> remove");
     }
 

--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -5,7 +5,6 @@ use crate::{event::AppEvent, ui::resource_table::ResourceTable, utils::is_contai
 use super::common::{TableStyle, render_footer};
 use bollard::secret::{ContainerStateStatusEnum, ContainerSummary};
 use color_eyre::Result;
-use ratatui::style::Stylize;
 use ratatui::{
     Frame,
     crossterm::event::{KeyCode, KeyEvent},

--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -201,6 +201,7 @@ fn get_footer_text(show_all: bool, is_running: Option<bool>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bollard::secret::PortTypeEnum;
 
     fn summary_with_state(state: &str) -> ContainerSummary {
         ContainerSummary {
@@ -261,5 +262,168 @@ mod tests {
         assert_eq!(cells[2], "-"); // image
         assert_eq!(cells[3], "-"); // state (EMPTY)
         assert_eq!(cells[4], "-"); // ports
+    }
+
+    #[test]
+    fn get_footer_text_variants() {
+        let text = get_footer_text(true, None);
+        assert_eq!(text, " <Ent> details | <T> All");
+
+        let text = get_footer_text(true, Some(true));
+        assert!(text.contains("restart | <S> stop | <X> kill"));
+        assert!(text.contains("<T> All"));
+
+        let text = get_footer_text(false, Some(false));
+        assert!(text.contains("<R> start"));
+        assert!(text.contains("<T> Running"));
+    }
+
+    #[test]
+    fn error_message_extracts_third_colon_segment() {
+        let table = ContainerTable::default();
+        assert_eq!(table.error_message("a:b:message"), "message");
+        assert_eq!(table.error_message("a:b"), "Something went wrong...");
+    }
+
+    fn summary_with_ports(id: &str, state: &str) -> ContainerSummary {
+        ContainerSummary {
+            id: Some(id.to_string()),
+            names: Some(vec![format!("/{id}")]),
+            image: Some("image".to_string()),
+            state: Some(state.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn handle_resource_key_event_dispatches_expected_events() {
+        let mut table = ContainerTable::default();
+        let rows = ContainerTableRow::from_list(vec![
+            summary_with_ports("running-id", "running"),
+            summary_with_ports("exited-id", "exited"),
+        ]);
+        table.update_with_items(rows);
+        table.select_row(0);
+
+        let id = table.selected_row().unwrap().id.clone();
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('r')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RestartContainer(got))) => assert_eq!(got, id),
+            _ => panic!("expected RestartContainer"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('s')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::StopContainer(got))) => assert_eq!(got, id),
+            _ => panic!("expected StopContainer"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('x')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::KillContainer(got))) => assert_eq!(got, id),
+            _ => panic!("expected KillContainer"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Enter))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::GoToContainerDetails(got))) => assert_eq!(got, id),
+            _ => panic!("expected GoToContainerDetails"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Delete))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveContainer(got))) => assert_eq!(got, id),
+            _ => panic!("expected RemoveContainer"),
+        }
+    }
+
+    #[test]
+    fn toggle_show_all_shrinks_visible_rows_and_clamps_selection() {
+        let mut table = ContainerTable::default();
+        let rows = ContainerTableRow::from_list(vec![
+            summary_with_ports("running-id", "running"),
+            summary_with_ports("exited-id", "exited"),
+        ]);
+        table.update_with_items(rows);
+        table.info.row_heights = vec![DEFAULT_ROW_HEIGHT];
+
+        assert_eq!(table.visible_indices().len(), 2);
+
+        // Select the last index before toggling, then verify it gets clamped.
+        table.select_row(1);
+
+        table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('t')))
+            .unwrap();
+
+        assert_eq!(table.visible_indices().len(), 1);
+        let selected = table.table_info().state.selected().unwrap();
+        assert!(selected < table.visible_indices().len());
+    }
+
+    #[test]
+    fn height_reflects_port_count() {
+        let no_ports = ContainerTableRow {
+            id: "id".to_string(),
+            name: "name".to_string(),
+            image: "image".to_string(),
+            state: ContainerStateStatusEnum::RUNNING,
+            ports: vec![],
+        };
+        assert_eq!(no_ports.height(), DEFAULT_ROW_HEIGHT);
+
+        let two_ports = ContainerTableRow {
+            ports: vec![
+                PortMapping {
+                    private: 80,
+                    public: 8080,
+                    protocol: PortTypeEnum::TCP,
+                },
+                PortMapping {
+                    private: 443,
+                    public: 8443,
+                    protocol: PortTypeEnum::TCP,
+                },
+            ],
+            ..no_ports
+        };
+        assert_eq!(two_ports.height(), 4);
+    }
+
+    #[test]
+    fn cells_joins_multiple_ports_with_newline() {
+        let row = ContainerTableRow {
+            id: "id".to_string(),
+            name: "name".to_string(),
+            image: "image".to_string(),
+            state: ContainerStateStatusEnum::RUNNING,
+            ports: vec![
+                PortMapping {
+                    private: 80,
+                    public: 8080,
+                    protocol: PortTypeEnum::TCP,
+                },
+                PortMapping {
+                    private: 443,
+                    public: 8443,
+                    protocol: PortTypeEnum::TCP,
+                },
+            ],
+        };
+
+        let cells = row.cells();
+        assert!(cells[4].contains('\n'));
+        assert_eq!(cells[4].matches('\n').count(), 1);
     }
 }

--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -16,6 +16,7 @@ pub struct ContainerTable {
     info: ResourceTableInfo<ContainerTableRow>,
 }
 
+#[derive(PartialEq)]
 pub struct ContainerTableRow {
     id: String,
     name: String,

--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -102,7 +102,7 @@ impl ResourceTable for ContainerTable {
                 ('x', Some(id)) => KeyOutcome::Handled(Some(AppEvent::KillContainer(id))),
                 _ => KeyOutcome::Fallthrough,
             },
-            _ => KeyOutcome::Handled(None),
+            _ => KeyOutcome::Fallthrough,
         };
 
         Ok(outcome)
@@ -359,6 +359,42 @@ mod tests {
             KeyOutcome::Handled(Some(AppEvent::RemoveContainer(got))) => assert_eq!(got, id),
             _ => panic!("expected RemoveContainer"),
         }
+    }
+
+    #[test]
+    fn esc_and_arrow_keys_fall_through_to_shared_navigation() {
+        let mut table = ContainerTable::default();
+        let rows = ContainerTableRow::from_list(vec![
+            summary_with_ports("running-id", "running"),
+            summary_with_ports("other-id", "running"),
+        ]);
+        table.update_with_items(rows);
+        table.info.row_heights = vec![DEFAULT_ROW_HEIGHT, DEFAULT_ROW_HEIGHT];
+        table.select_row(0);
+
+        for code in [KeyCode::Esc, KeyCode::Up, KeyCode::Down] {
+            match table
+                .handle_resource_key_event(KeyEvent::from(code))
+                .unwrap()
+            {
+                KeyOutcome::Fallthrough => {}
+                _ => panic!("expected {code:?} to fall through to shared navigation"),
+            }
+        }
+
+        // End-to-end through the shared handler: Esc quits, arrows move the selection.
+        let event = table
+            .handle_key_event(KeyEvent::from(KeyCode::Esc))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::Quit)));
+
+        table
+            .handle_key_event(KeyEvent::from(KeyCode::Down))
+            .unwrap();
+        assert_eq!(table.table_info().state.selected(), Some(1));
+
+        table.handle_key_event(KeyEvent::from(KeyCode::Up)).unwrap();
+        assert_eq!(table.table_info().state.selected(), Some(0));
     }
 
     #[test]

--- a/src/ui/container_table.rs
+++ b/src/ui/container_table.rs
@@ -1,8 +1,9 @@
+use crate::docker::models::{PortMapping, parse_container_state, state_label};
 use crate::ui::resource_table::ResourceTableInfo;
 use crate::{event::AppEvent, ui::resource_table::ResourceTable, utils::is_container_running};
 
 use super::common::{TableStyle, render_footer};
-use bollard::secret::{ContainerSummary, Port, PortTypeEnum};
+use bollard::secret::{ContainerStateStatusEnum, ContainerSummary};
 use color_eyre::Result;
 use ratatui::style::Stylize;
 use ratatui::{
@@ -26,8 +27,8 @@ pub struct ContainerTableRow {
     id: String,
     name: String,
     image: String,
-    state: String,
-    ports: String,
+    state: ContainerStateStatusEnum,
+    ports: Vec<PortMapping>,
 }
 
 impl Default for ContainerTable {
@@ -96,7 +97,7 @@ impl ResourceTable for ContainerTable {
             .info
             .items
             .iter()
-            .filter(|container| show_all || String::eq(&container.state, "running"))
+            .filter(|container| show_all || is_container_running(container.state))
             .collect();
         let visible_count = visible_items.len();
 
@@ -109,14 +110,9 @@ impl ResourceTable for ContainerTable {
                 } else {
                     self.style.alt_row_style
                 };
-                let item = container.ref_array();
-                let ports: Vec<&str> = container
-                    .ports
-                    .split("\n")
-                    .filter(|s| !s.is_empty())
-                    .collect();
-
-                let height = if ports.is_empty() { 3 } else { ports.len() + 2 };
+                let item = container.cells();
+                let port_count = container.ports.len();
+                let height = if port_count == 0 { 3 } else { port_count + 2 };
                 if index < visible_count - 1 {
                     self.info.row_heights.push(height);
                 }
@@ -150,7 +146,7 @@ impl ResourceTable for ContainerTable {
 
         let is_selected_container_running = self
             .get_selected_row()
-            .map(|c| is_container_running(&c.state));
+            .map(|c| is_container_running(c.state));
         let mut footer_text = get_footer_text(self.show_all, is_selected_container_running);
 
         if let Some(err) = &self.err {
@@ -170,7 +166,7 @@ impl ContainerTable {
             .items
             .iter()
             .enumerate()
-            .filter(|(_, container)| self.show_all || String::eq(&container.state, "running"))
+            .filter(|(_, container)| self.show_all || is_container_running(container.state))
             .map(|(index, _)| index)
             .collect()
     }
@@ -242,8 +238,24 @@ impl ContainerTable {
 }
 
 impl ContainerTableRow {
-    const fn ref_array(&self) -> [&String; 5] {
-        [&self.id, &self.name, &self.image, &self.state, &self.ports]
+    fn cells(&self) -> [String; 5] {
+        let ports_text = if self.ports.is_empty() {
+            "-".to_string()
+        } else {
+            self.ports
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<String>>()
+                .join("\n")
+        };
+
+        [
+            self.id.clone(),
+            self.name.clone(),
+            self.image.clone(),
+            state_label(self.state),
+            ports_text,
+        ]
     }
 
     pub fn from_list(containers: Vec<ContainerSummary>) -> Vec<Self> {
@@ -253,13 +265,13 @@ impl ContainerTableRow {
             .collect::<Vec<ContainerTableRow>>();
 
         result_list.sort_by(|p, n| {
-            let p_is_running = p.state.starts_with("r");
-            let n_is_running = n.state.starts_with("r");
+            let p_is_running = p.state == ContainerStateStatusEnum::RUNNING;
+            let n_is_running = n.state == ContainerStateStatusEnum::RUNNING;
 
             match (p_is_running, n_is_running) {
                 (true, false) => std::cmp::Ordering::Less,
                 (false, true) => std::cmp::Ordering::Greater,
-                _ => p.state.cmp(&n.state),
+                _ => p.state.as_ref().cmp(n.state.as_ref()),
             }
         });
 
@@ -278,29 +290,14 @@ impl ContainerTableRow {
             id: container.id.as_deref().unwrap_or("-").to_string(),
             name,
             image: container.image.as_deref().unwrap_or("-").to_string(),
-            state: container.state.as_deref().unwrap_or("-").to_string(),
+            state: parse_container_state(container.state.as_deref()),
             ports: container
                 .ports
-                .as_ref()
-                .map_or("-".to_string(), |p| get_ports_text(p)),
+                .as_deref()
+                .map(PortMapping::from_summary_ports)
+                .unwrap_or_default(),
         }
     }
-}
-
-fn get_ports_text(ports: &[Port]) -> String {
-    let mut filtered_ports: Vec<(u16, u16, PortTypeEnum)> = ports
-        .iter()
-        .filter_map(|p| Some((p.private_port, p.public_port?, p.typ?)))
-        .collect();
-
-    filtered_ports.sort_by_key(|&(private, _, _)| private);
-    filtered_ports.dedup();
-
-    filtered_ports
-        .iter()
-        .map(|&(private, public, typ)| format!("{private}:{public}/{typ}"))
-        .collect::<Vec<String>>()
-        .join("\n")
 }
 
 fn get_footer_text(show_all: bool, is_running: Option<bool>) -> String {
@@ -317,4 +314,70 @@ fn get_footer_text(show_all: bool, is_running: Option<bool>) -> String {
     }
 
     format!(" <Ent> details | <T> {toggle_text}{op_text}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary_with_state(state: &str) -> ContainerSummary {
+        ContainerSummary {
+            id: Some(format!("id-{state}")),
+            names: Some(vec![format!("/{state}")]),
+            image: Some("image".to_string()),
+            state: Some(state.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn from_list_sorts_running_first_and_others_alphabetically_by_state() {
+        let containers = vec![
+            summary_with_state("exited"),
+            summary_with_state("restarting"),
+            summary_with_state("created"),
+            summary_with_state("running"),
+            summary_with_state("paused"),
+        ];
+
+        let rows = ContainerTableRow::from_list(containers);
+        let states: Vec<ContainerStateStatusEnum> = rows.iter().map(|r| r.state).collect();
+
+        // Running must come first.
+        assert_eq!(states[0], ContainerStateStatusEnum::RUNNING);
+        // "restarting" is not "running", so it must not be treated as running.
+        assert_ne!(states[1], ContainerStateStatusEnum::RESTARTING);
+
+        // Remaining rows are ordered alphabetically by state name:
+        // created < exited < paused < restarting.
+        let non_running_states: Vec<ContainerStateStatusEnum> = states[1..].to_vec();
+        assert_eq!(
+            non_running_states,
+            vec![
+                ContainerStateStatusEnum::CREATED,
+                ContainerStateStatusEnum::EXITED,
+                ContainerStateStatusEnum::PAUSED,
+                ContainerStateStatusEnum::RESTARTING,
+            ]
+        );
+    }
+
+    #[test]
+    fn from_strips_leading_slash_from_name() {
+        let container = summary_with_state("running");
+        let row = ContainerTableRow::from(&container);
+        assert_eq!(row.name, "running");
+    }
+
+    #[test]
+    fn cells_fall_back_to_dash_for_missing_fields() {
+        let container = ContainerSummary::default();
+        let row = ContainerTableRow::from(&container);
+        let cells = row.cells();
+
+        assert_eq!(cells[0], "-"); // id
+        assert_eq!(cells[2], "-"); // image
+        assert_eq!(cells[3], "-"); // state (EMPTY)
+        assert_eq!(cells[4], "-"); // ports
+    }
 }

--- a/src/ui/image_table.rs
+++ b/src/ui/image_table.rs
@@ -140,4 +140,89 @@ mod tests {
 
         assert_eq!(ids, vec!["b", "c", "a"]);
     }
+
+    #[test]
+    fn error_message_matches_realistic_daemon_strings() {
+        let table = ImageTable::default();
+
+        let stopped_msg = "Error response from daemon: conflict: unable to delete abc123def456 \
+            (must be forced) - image is being used by stopped container abc123";
+        assert_eq!(
+            table.error_message(stopped_msg),
+            "(must be forced) - image is being used by stopped container abc123"
+        );
+
+        let running_msg = "Error response from daemon: conflict: unable to delete xyz789 \
+            (cannot be forced) - image is being used by running container xyz";
+        assert_eq!(
+            table.error_message(running_msg),
+            "(cannot be forced) - image is being used by running container xyz"
+        );
+
+        assert_eq!(
+            table.error_message("some unrelated error"),
+            "Something went wrong..."
+        );
+    }
+
+    #[test]
+    fn height_reflects_tag_count() {
+        let no_tags = ImageTableRow {
+            id: "id".to_string(),
+            tags: String::new(),
+            size: "0".to_string(),
+            created: "now".to_string(),
+            created_epoch: 0,
+        };
+        assert_eq!(no_tags.height(), DEFAULT_ROW_HEIGHT);
+
+        let two_tags = ImageTableRow {
+            tags: "repo:tag1\nrepo:tag2".to_string(),
+            ..no_tags
+        };
+        assert_eq!(two_tags.height(), 4);
+    }
+
+    #[test]
+    fn handle_resource_key_event_dispatches_expected_events() {
+        let mut table = ImageTable::default();
+        let images = vec![image(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd",
+            100,
+        )];
+        table.update_with_items(ImageTableRow::from_list(images));
+        table.select_row(0);
+        let id = table.selected_row().unwrap().id.clone();
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('d')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveImage(got, false))) => assert_eq!(got, id),
+            _ => panic!("expected RemoveImage(id, false)"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Delete))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveImage(got, false))) => assert_eq!(got, id),
+            _ => panic!("expected RemoveImage(id, false)"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('f')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveImage(got, true))) => assert_eq!(got, id),
+            _ => panic!("expected RemoveImage(id, true)"),
+        }
+
+        assert!(matches!(
+            table
+                .handle_resource_key_event(KeyEvent::from(KeyCode::Char('z')))
+                .unwrap(),
+            KeyOutcome::Fallthrough
+        ));
+    }
 }

--- a/src/ui/image_table.rs
+++ b/src/ui/image_table.rs
@@ -2,7 +2,6 @@ use bollard::secret::ImageSummary;
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::layout::Constraint;
-use regex::Regex;
 
 use crate::{
     event::AppEvent,
@@ -13,9 +12,6 @@ use crate::{
         },
     },
 };
-
-const REGEX_DELETE_IMG_ERR: &str =
-    r"\((?:cannot|must) be forced\) - image is being used by (?:running|stopped) container \w+";
 
 #[derive(Default)]
 pub struct ImageTable {
@@ -69,15 +65,6 @@ impl ResourceTable for ImageTable {
         };
 
         Ok(outcome)
-    }
-
-    fn error_message(&self, raw: &str) -> String {
-        Regex::new(REGEX_DELETE_IMG_ERR)
-            .ok()
-            .and_then(|re| re.find(raw))
-            .map(|m| m.as_str())
-            .unwrap_or("Something went wrong...")
-            .to_string()
     }
 }
 
@@ -139,30 +126,6 @@ mod tests {
         let ids: Vec<String> = rows.iter().map(|r| r.id.clone()).collect();
 
         assert_eq!(ids, vec!["b", "c", "a"]);
-    }
-
-    #[test]
-    fn error_message_matches_realistic_daemon_strings() {
-        let table = ImageTable::default();
-
-        let stopped_msg = "Error response from daemon: conflict: unable to delete abc123def456 \
-            (must be forced) - image is being used by stopped container abc123";
-        assert_eq!(
-            table.error_message(stopped_msg),
-            "(must be forced) - image is being used by stopped container abc123"
-        );
-
-        let running_msg = "Error response from daemon: conflict: unable to delete xyz789 \
-            (cannot be forced) - image is being used by running container xyz";
-        assert_eq!(
-            table.error_message(running_msg),
-            "(cannot be forced) - image is being used by running container xyz"
-        );
-
-        assert_eq!(
-            table.error_message("some unrelated error"),
-            "Something went wrong..."
-        );
     }
 
     #[test]

--- a/src/ui/image_table.rs
+++ b/src/ui/image_table.rs
@@ -102,8 +102,15 @@ impl ResourceRow for ImageTableRow {
     }
 
     fn sort_rows(rows: &mut Vec<Self>) {
-        rows.sort_by_key(|r| r.created_epoch);
-        rows.reverse();
+        // `created` has second resolution, so multi-tag builds of the same
+        // project tie on it; break ties deterministically so rows do not
+        // follow the daemon's unstable tie order and swap on every refresh.
+        rows.sort_by(|a, b| {
+            b.created_epoch
+                .cmp(&a.created_epoch)
+                .then_with(|| a.tags.cmp(&b.tags))
+                .then_with(|| a.id.cmp(&b.id))
+        });
     }
 }
 
@@ -126,6 +133,40 @@ mod tests {
         let ids: Vec<String> = rows.iter().map(|r| r.id.clone()).collect();
 
         assert_eq!(ids, vec!["b", "c", "a"]);
+    }
+
+    #[test]
+    fn from_list_orders_identical_creation_times_deterministically() {
+        let mut dev = image("aaa", 100);
+        dev.repo_tags = vec!["devmon-agent:dev".to_string()];
+        let mut local = image("bbb", 100);
+        local.repo_tags = vec!["devmon-agent:local".to_string()];
+
+        // The daemon's tie order is unstable; both input orders must yield
+        // the same on-screen order.
+        let tags_of = |rows: &[ImageTableRow]| -> Vec<String> {
+            rows.iter().map(|r| r.tags.clone()).collect()
+        };
+
+        let one_way = ImageTableRow::from_list(vec![dev.clone(), local.clone()]);
+        let other_way = ImageTableRow::from_list(vec![local, dev]);
+
+        assert_eq!(tags_of(&one_way), tags_of(&other_way));
+        assert_eq!(
+            tags_of(&one_way),
+            vec!["devmon-agent:dev", "devmon-agent:local"]
+        );
+    }
+
+    #[test]
+    fn from_list_breaks_full_ties_by_id() {
+        let untagged_b = image("bbb", 100);
+        let untagged_a = image("aaa", 100);
+
+        let rows = ImageTableRow::from_list(vec![untagged_b, untagged_a]);
+        let ids: Vec<String> = rows.iter().map(|r| r.id.clone()).collect();
+
+        assert_eq!(ids, vec!["aaa", "bbb"]);
     }
 
     #[test]

--- a/src/ui/image_table.rs
+++ b/src/ui/image_table.rs
@@ -18,7 +18,7 @@ pub struct ImageTable {
     info: ResourceTableInfo<ImageTableRow>,
 }
 
-#[derive(Default)]
+#[derive(Default, PartialEq)]
 pub struct ImageTableRow {
     id: String,
     tags: String,

--- a/src/ui/image_table.rs
+++ b/src/ui/image_table.rs
@@ -4,7 +4,7 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     Frame,
     layout::{Constraint, Rect},
-    style::{Style, Stylize},
+    style::Style,
     text::Text,
     widgets::{Cell, HighlightSpacing, Row, Table},
 };

--- a/src/ui/image_table.rs
+++ b/src/ui/image_table.rs
@@ -1,34 +1,25 @@
 use bollard::secret::ImageSummary;
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
-use ratatui::{
-    Frame,
-    layout::{Constraint, Rect},
-    style::{Style, Stylize},
-    text::Text,
-    widgets::{Cell, HighlightSpacing, Row, Table},
-};
+use ratatui::layout::Constraint;
+use regex::Regex;
 
 use crate::{
     event::AppEvent,
     ui::{
-        common::{TableStyle, render_footer, time_ago_string},
-        resource_table::{ResourceTable, ResourceTableInfo},
+        common::time_ago_string,
+        resource_table::{
+            DEFAULT_ROW_HEIGHT, KeyOutcome, ResourceRow, ResourceTable, ResourceTableInfo,
+        },
     },
 };
 
-use regex::Regex;
-
-const REFRESH_AFTER_TICK: u8 = 10;
-const REGEX_DELETE_IMG_ERR: &str = r"\((?:cannot|must) be forced\) - image is being used by (?:running|stopped) container \w+";
-const DEFAULT_FOOTER: &str = " <Del/D> remove | <F> force remove";
+const REGEX_DELETE_IMG_ERR: &str =
+    r"\((?:cannot|must) be forced\) - image is being used by (?:running|stopped) container \w+";
 
 #[derive(Default)]
 pub struct ImageTable {
-    style: TableStyle,
-    skipped_tick_count_for_refresh: u8,
     info: ResourceTableInfo<ImageTableRow>,
-    err: Option<String>,
 }
 
 #[derive(Default)]
@@ -37,126 +28,63 @@ pub struct ImageTableRow {
     tags: String,
     size: String,
     created: String,
+    created_epoch: i64,
 }
 
 impl ResourceTable for ImageTable {
     type RowType = ImageTableRow;
 
-    fn get_table_info(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
+    const HEADERS: &'static [&'static str] = &["ID", "Tags", "Size", "Created"];
+    const WIDTHS: &'static [Constraint] = &[
+        Constraint::Length(15),
+        Constraint::Min(15),
+        Constraint::Min(0),
+        Constraint::Length(27),
+    ];
+    const DEFAULT_FOOTER: &'static str = " <Del/D> remove | <F> force remove";
+
+    fn table_info(&self) -> &ResourceTableInfo<Self::RowType> {
+        &self.info
+    }
+
+    fn table_info_mut(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
         &mut self.info
     }
 
-    fn render_table(&mut self, frame: &mut Frame, area: Rect) {
-        let header = ["ID", "Tags", "Size", "Created"].into_iter()
-            .map(Cell::from)
-            .collect::<Row>()
-            .style(self.style.header_style)
-            .height(1);
-
-        self.info.row_heights.clear();
-
-        let rows = self.info.items.iter().enumerate().map(|(index, image)| {
-            let row_style = if index % 2 == 0 { self.style.row_style } else { self.style.alt_row_style };
-            let item = image.ref_array();
-            let tags: Vec<&str> = image.tags.split("\n").filter(|s| !s.is_empty()).collect();
-
-            let height = if tags.is_empty() { 3 } else { tags.len() + 2 };
-            if index < self.info.items.len() - 1 {
-                self.info.row_heights.push(height);
-            }
-
-            item.into_iter()
-                .map(|content| Cell::from(Text::from(format!("\n{content}\n"))))
-                .collect::<Row>()
-                .style(row_style)
-                .height(height as u16)
-        });
-
-        let widths = vec![
-            Constraint::Length(15),
-            Constraint::Min(15),
-            Constraint::Min(0),
-            Constraint::Length(27),
-        ];
-
-        let table = Table::new(rows, widths)
-            .header(header)
-            .row_highlight_style(self.style.selected_row_style)
-            .highlight_symbol(Text::from(vec!["".into(), " ● ".into()]))
-            .highlight_spacing(HighlightSpacing::Always);
-
-        frame.render_stateful_widget(table, area, &mut self.info.state);
+    fn refresh_event(&self) -> AppEvent {
+        AppEvent::UpdateImages
     }
 
-    fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
-        let mut border_style = None;
-        let mut footer_text = DEFAULT_FOOTER.to_string();
-
-        if let Some(err) = &self.err {
-            border_style = Some(Style::new().red());
-            footer_text = err.clone();
-        }
-
-        render_footer(frame, area, footer_text, border_style);
-    }
-}
-
-impl ImageTable {
-    pub fn handle_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
-        if self.err.is_some() {
-            self.err = None;
-            return Ok(None);
-        }
-
-        let event = match key_event.code {
-            KeyCode::Delete | KeyCode::Char('d') => self.get_selected_row()
-                .map(|i| AppEvent::RemoveImage(i.id.clone(), false)),
-            KeyCode::Char('f') => self.get_selected_row()
-                .map(|i| AppEvent::RemoveImage(i.id.clone(), true)),
-            _ => self.handle_nav_key_event(key_event)?,
+    fn handle_resource_key_event(&mut self, key_event: KeyEvent) -> Result<KeyOutcome> {
+        let outcome = match key_event.code {
+            KeyCode::Delete | KeyCode::Char('d') => KeyOutcome::Handled(
+                self.selected_row()
+                    .map(|i| AppEvent::RemoveImage(i.id.clone(), false)),
+            ),
+            KeyCode::Char('f') => KeyOutcome::Handled(
+                self.selected_row()
+                    .map(|i| AppEvent::RemoveImage(i.id.clone(), true)),
+            ),
+            _ => KeyOutcome::Fallthrough,
         };
 
-        Ok(event)
+        Ok(outcome)
     }
 
-    pub fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        self.draw_default(frame, area)
-    }
-
-    pub fn tick(&mut self) -> Result<Option<AppEvent>> {
-        if self.skipped_tick_count_for_refresh <= REFRESH_AFTER_TICK {
-            self.skipped_tick_count_for_refresh += 1;
-            return Ok(None);
-        }
-
-        self.skipped_tick_count_for_refresh = 0;
-        Ok(Some(AppEvent::UpdateImages))
-    }
-
-    pub fn show_remove_image_err(&mut self, err: String) {
-        let err_msg = Regex::new(REGEX_DELETE_IMG_ERR).ok()
-            .and_then(|re| re.find(&err))
+    fn error_message(&self, raw: &str) -> String {
+        Regex::new(REGEX_DELETE_IMG_ERR)
+            .ok()
+            .and_then(|re| re.find(raw))
             .map(|m| m.as_str())
-            .unwrap_or_else(|| "Something went wrong...")
-            .to_string();
-
-        self.err = Some(format!("[ERR] {}", err_msg.trim()))
+            .unwrap_or("Something went wrong...")
+            .to_string()
     }
 }
 
-impl ImageTableRow {
-    const fn ref_array(&self) -> [&String; 4] {
-        [&self.id, &self.tags, &self.size, &self.created]
-    }
+impl ResourceRow for ImageTableRow {
+    type Source = ImageSummary;
 
-    pub fn from_list(images: Vec<ImageSummary>) -> Vec<Self> {
-        let mut result = images.clone();
-        result.sort_by_key(|i| i.created);
-        result.reverse();
-        result.iter().map(Self::from).collect::<Vec<Self>>()
-    }
-
-    fn from(image: &ImageSummary) -> Self {
+    fn from_source(image: &Self::Source) -> Self {
         let id = image.id.split(":").collect::<Vec<&str>>()[1].to_string();
 
         Self {
@@ -164,6 +92,52 @@ impl ImageTableRow {
             tags: image.repo_tags.join("\n"),
             size: image.size.to_string(),
             created: time_ago_string(image.created),
+            created_epoch: image.created,
         }
+    }
+
+    fn cells(&self) -> Vec<String> {
+        vec![
+            self.id.clone(),
+            self.tags.clone(),
+            self.size.clone(),
+            self.created.clone(),
+        ]
+    }
+
+    fn height(&self) -> usize {
+        let tags = self.tags.split('\n').filter(|s| !s.is_empty()).count();
+        if tags == 0 {
+            DEFAULT_ROW_HEIGHT
+        } else {
+            tags + 2
+        }
+    }
+
+    fn sort_rows(rows: &mut Vec<Self>) {
+        rows.sort_by_key(|r| r.created_epoch);
+        rows.reverse();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn image(id: &str, created: i64) -> ImageSummary {
+        ImageSummary {
+            id: format!("sha256:{id}"),
+            created,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn from_list_sorts_newest_first() {
+        let images = vec![image("a", 100), image("b", 300), image("c", 200)];
+        let rows = ImageTableRow::from_list(images);
+        let ids: Vec<String> = rows.iter().map(|r| r.id.clone()).collect();
+
+        assert_eq!(ids, vec!["b", "c", "a"]);
     }
 }

--- a/src/ui/info_block.rs
+++ b/src/ui/info_block.rs
@@ -41,7 +41,8 @@ pub trait ScrollableInfoBlock {
 
     fn tick(&mut self) -> Result<Option<AppEvent>>;
 
-    fn update_data(&mut self, data: Self::Data);
+    /// Returns true when the visible content changed.
+    fn update_data(&mut self, data: Self::Data) -> bool;
 
     fn get_scroll_info(&mut self) -> &mut ScrollInfo;
 
@@ -118,7 +119,9 @@ mod tests {
             Ok(None)
         }
 
-        fn update_data(&mut self, _data: Self::Data) {}
+        fn update_data(&mut self, _data: Self::Data) -> bool {
+            false
+        }
 
         fn get_scroll_info(&mut self) -> &mut ScrollInfo {
             &mut self.scroll

--- a/src/ui/info_block.rs
+++ b/src/ui/info_block.rs
@@ -93,3 +93,122 @@ pub trait ScrollableInfoBlock {
         scroll_info.vertical = scroll_info.max_vertical;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct TestBlock {
+        scroll: ScrollInfo,
+    }
+
+    impl ScrollableInfoBlock for TestBlock {
+        type Data = ();
+
+        fn handle_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
+            self.handle_nav_key_event(key_event)
+        }
+
+        fn draw(&mut self, _frame: &mut Frame, _area: Rect) -> Result<()> {
+            Ok(())
+        }
+
+        fn tick(&mut self) -> Result<Option<AppEvent>> {
+            Ok(None)
+        }
+
+        fn update_data(&mut self, _data: Self::Data) {}
+
+        fn get_scroll_info(&mut self) -> &mut ScrollInfo {
+            &mut self.scroll
+        }
+    }
+
+    fn block_with_bounds(max_vertical: usize, max_horizontal: usize) -> TestBlock {
+        TestBlock {
+            scroll: ScrollInfo {
+                max_vertical,
+                max_horizontal,
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn scroll_down_stops_at_max_vertical() {
+        let mut block = block_with_bounds(2, 0);
+        block.scroll_down();
+        block.scroll_down();
+        block.scroll_down();
+        assert_eq!(block.scroll.vertical, 2);
+    }
+
+    #[test]
+    fn scroll_up_clamps_at_zero() {
+        let mut block = block_with_bounds(5, 0);
+        block.scroll_up();
+        assert_eq!(block.scroll.vertical, 0);
+    }
+
+    #[test]
+    fn scroll_right_and_left_clamp() {
+        let mut block = block_with_bounds(0, 2);
+        block.scroll_right();
+        block.scroll_right();
+        block.scroll_right();
+        assert_eq!(block.scroll.horizontal, 2);
+
+        block.scroll_left();
+        block.scroll_left();
+        block.scroll_left();
+        assert_eq!(block.scroll.horizontal, 0);
+    }
+
+    #[test]
+    fn home_and_end_set_horizontal_bounds() {
+        let mut block = block_with_bounds(0, 10);
+        block.scroll.horizontal = 5;
+
+        block
+            .handle_key_event(KeyEvent::from(KeyCode::End))
+            .unwrap();
+        assert_eq!(block.scroll.horizontal, 10);
+
+        block
+            .handle_key_event(KeyEvent::from(KeyCode::Home))
+            .unwrap();
+        assert_eq!(block.scroll.horizontal, 0);
+    }
+
+    #[test]
+    fn page_up_and_page_down_set_vertical_bounds() {
+        let mut block = block_with_bounds(10, 0);
+        block.scroll.vertical = 5;
+
+        block
+            .handle_key_event(KeyEvent::from(KeyCode::PageDown))
+            .unwrap();
+        assert_eq!(block.scroll.vertical, 10);
+
+        block
+            .handle_key_event(KeyEvent::from(KeyCode::PageUp))
+            .unwrap();
+        assert_eq!(block.scroll.vertical, 0);
+    }
+
+    #[test]
+    fn esc_and_q_yield_back_event() {
+        let mut block = TestBlock::default();
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Esc))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::Back)));
+
+        let event = block
+            .handle_key_event(KeyEvent::from(KeyCode::Char('q')))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::Back)));
+    }
+}

--- a/src/ui/network_table.rs
+++ b/src/ui/network_table.rs
@@ -6,7 +6,6 @@ use crate::ui::resource_table::ResourceTableInfo;
 use bollard::secret::Network;
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
-use ratatui::style::Stylize;
 use ratatui::{
     Frame,
     layout::{Constraint, Rect},

--- a/src/ui/network_table.rs
+++ b/src/ui/network_table.rs
@@ -1,33 +1,20 @@
-use super::common::TableStyle;
-use super::common::render_footer;
-use crate::event::AppEvent;
-use crate::ui::resource_table::ResourceTable;
-use crate::ui::resource_table::ResourceTableInfo;
 use bollard::secret::Network;
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
-use ratatui::style::Stylize;
-use ratatui::{
-    Frame,
-    layout::{Constraint, Rect},
-    style::Style,
-    text::Text,
-    widgets::{Cell, HighlightSpacing, Row, Table},
-};
+use ratatui::layout::Constraint;
 use regex::Regex;
 
-const ROW_HEIGHT: usize = 3;
-const REFRESH_AFTER_TICK: u8 = 10;
+use crate::{
+    event::AppEvent,
+    ui::resource_table::{KeyOutcome, ResourceRow, ResourceTable, ResourceTableInfo},
+};
+
 const REGEX_NETWORK_IN_USE: &str = r":(?:[^:]+:)?\s*([^\(]+)";
 const REGEX_NETWORK_CREATED_AT: &str = r"\.\d+";
-const DEFAULT_FOOTER: &str = " <Del/D> remove";
 
 #[derive(Default)]
 pub struct NetworkTable {
-    style: TableStyle,
-    skipped_tick_count_for_refresh: u8,
     info: ResourceTableInfo<NetworkTableRow>,
-    err: Option<String>,
 }
 
 #[derive(Default)]
@@ -41,116 +28,53 @@ pub struct NetworkTableRow {
 impl ResourceTable for NetworkTable {
     type RowType = NetworkTableRow;
 
-    fn get_table_info(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
+    const HEADERS: &'static [&'static str] = &["ID", "Name", "Driver", "Created At"];
+    const WIDTHS: &'static [Constraint] = &[
+        Constraint::Length(15),
+        Constraint::Min(15),
+        Constraint::Min(0),
+        Constraint::Length(27),
+    ];
+    const DEFAULT_FOOTER: &'static str = " <Del/D> remove";
+
+    fn table_info(&self) -> &ResourceTableInfo<Self::RowType> {
+        &self.info
+    }
+
+    fn table_info_mut(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
         &mut self.info
     }
 
-    fn render_table(&mut self, frame: &mut Frame, area: Rect) {
-        let header = ["ID", "Name", "Driver", "Created At"].into_iter()
-            .map(Cell::from)
-            .collect::<Row>()
-            .style(self.style.header_style)
-            .height(1);
-
-        self.info.row_heights.clear();
-
-        let rows = self.info.items.iter().enumerate().map(|(index, network)| {
-            let row_style = if index % 2 == 0 { self.style.row_style} else { self.style.alt_row_style };
-            let item = network.ref_array();
-
-            if index < self.info.items.len() - 1 {
-                self.info.row_heights.push(ROW_HEIGHT);
-            }
-
-            item.into_iter()
-                .map(|content| Cell::from(Text::from(format!("\n{content}\n"))))
-                .collect::<Row>()
-                .style(row_style)
-                .height(ROW_HEIGHT as u16)
-        });
-
-        let widths = vec![
-            Constraint::Length(15),
-            Constraint::Min(15),
-            Constraint::Min(0),
-            Constraint::Length(27),
-        ];
-
-        let table = Table::new(rows, widths)
-            .header(header)
-            .row_highlight_style(self.style.selected_row_style)
-            .highlight_symbol(Text::from(vec!["".into(), " ● ".into()]))
-            .highlight_spacing(HighlightSpacing::Always);
-
-        frame.render_stateful_widget(table, area, &mut self.info.state);
+    fn refresh_event(&self) -> AppEvent {
+        AppEvent::UpdateNetworks
     }
 
-    fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
-        let mut border_style = None;
-        let mut footer_text = DEFAULT_FOOTER.to_string();
-
-        if let Some(err) = &self.err {
-            border_style = Some(Style::new().red());
-            footer_text = err.clone();
-        }
-
-        render_footer(frame, area, footer_text, border_style);
-    }
-}
-
-impl NetworkTable {
-    pub fn handle_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
-        if self.err.is_some() {
-            self.err = None;
-            return Ok(None);
-        }
-
-        let event = match key_event.code {
-            KeyCode::Delete | KeyCode::Char('d') => self.get_selected_row()
-                .map(|n| AppEvent::RemoveNetwork(n.name.clone())),
-            _ => self.handle_nav_key_event(key_event)?,
+    fn handle_resource_key_event(&mut self, key_event: KeyEvent) -> Result<KeyOutcome> {
+        let outcome = match key_event.code {
+            KeyCode::Delete | KeyCode::Char('d') => KeyOutcome::Handled(
+                self.selected_row()
+                    .map(|n| AppEvent::RemoveNetwork(n.name.clone())),
+            ),
+            _ => KeyOutcome::Fallthrough,
         };
 
-        Ok(event)
+        Ok(outcome)
     }
 
-    pub fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        self.draw_default(frame, area)
-    }
-
-    pub fn tick(&mut self) -> Result<Option<AppEvent>> {
-        if self.skipped_tick_count_for_refresh <= REFRESH_AFTER_TICK {
-            self.skipped_tick_count_for_refresh += 1;
-            return Ok(None);
-        }
-
-        self.skipped_tick_count_for_refresh = 0;
-        Ok(Some(AppEvent::UpdateNetworks))
-    }
-
-    pub fn show_remove_network_err(&mut self, err: String) {
-        let err_msg = Regex::new(REGEX_NETWORK_IN_USE).ok()
-            .and_then(|re| re.captures(&err))
+    fn error_message(&self, raw: &str) -> String {
+        Regex::new(REGEX_NETWORK_IN_USE)
+            .ok()
+            .and_then(|re| re.captures(raw))
             .and_then(|caps| caps.get(1))
             .map(|m| m.as_str().to_string())
-            .unwrap_or_else(|| "Something went wrong...".to_string());
-
-        self.err = Some(format!("[ERR] {}", err_msg.trim()))
+            .unwrap_or_else(|| "Something went wrong...".to_string())
     }
 }
 
-impl NetworkTableRow {
-    const fn ref_array(&self) -> [&String; 4] {
-        [&self.id, &self.name, &self.driver, &self.created_at]
-    }
+impl ResourceRow for NetworkTableRow {
+    type Source = Network;
 
-    pub fn from_list(networks: Vec<Network>) -> Vec<Self> {
-        let mut result = networks.iter().map(Self::from).collect::<Vec<Self>>();
-        result.sort_by_key(|n| n.name.clone());
-        result
-    }
-
-    fn from(network: &Network) -> Self {
+    fn from_source(network: &Self::Source) -> Self {
         let id = format!("{}...", &network.id.as_deref().unwrap_or("-")[..12]);
 
         let raw_created = network.created.as_deref().unwrap_or_default();
@@ -163,5 +87,45 @@ impl NetworkTableRow {
             driver: network.driver.as_deref().unwrap_or("-").to_string(),
             created_at,
         }
+    }
+
+    fn cells(&self) -> Vec<String> {
+        vec![
+            self.id.clone(),
+            self.name.clone(),
+            self.driver.clone(),
+            self.created_at.clone(),
+        ]
+    }
+
+    fn sort_rows(rows: &mut Vec<Self>) {
+        rows.sort_by_key(|n| n.name.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn network(id: &str, name: &str) -> Network {
+        Network {
+            id: Some(id.to_string()),
+            name: Some(name.to_string()),
+            driver: Some("bridge".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn from_list_sorts_by_name() {
+        let networks = vec![
+            network("111111111111", "charlie"),
+            network("222222222222", "alpha"),
+            network("333333333333", "bravo"),
+        ];
+        let rows = NetworkTableRow::from_list(networks);
+        let names: Vec<String> = rows.iter().map(|r| r.name.clone()).collect();
+
+        assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
     }
 }

--- a/src/ui/network_table.rs
+++ b/src/ui/network_table.rs
@@ -9,7 +9,6 @@ use crate::{
     ui::resource_table::{KeyOutcome, ResourceRow, ResourceTable, ResourceTableInfo},
 };
 
-const REGEX_NETWORK_IN_USE: &str = r":(?:[^:]+:)?\s*([^\(]+)";
 const REGEX_NETWORK_CREATED_AT: &str = r"\.\d+";
 
 #[derive(Default)]
@@ -59,15 +58,6 @@ impl ResourceTable for NetworkTable {
         };
 
         Ok(outcome)
-    }
-
-    fn error_message(&self, raw: &str) -> String {
-        Regex::new(REGEX_NETWORK_IN_USE)
-            .ok()
-            .and_then(|re| re.captures(raw))
-            .and_then(|caps| caps.get(1))
-            .map(|m| m.as_str().to_string())
-            .unwrap_or_else(|| "Something went wrong...".to_string())
     }
 }
 
@@ -127,22 +117,6 @@ mod tests {
         let names: Vec<String> = rows.iter().map(|r| r.name.clone()).collect();
 
         assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
-    }
-
-    #[test]
-    fn error_message_captures_daemon_in_use_segment() {
-        let table = NetworkTable::default();
-        let raw = "Error response from daemon: error while removing network: network foo id \
-            abc123def456 has active endpoints";
-        assert_eq!(
-            table.error_message(raw),
-            "network foo id abc123def456 has active endpoints"
-        );
-
-        assert_eq!(
-            table.error_message("no colons here"),
-            "Something went wrong..."
-        );
     }
 
     #[test]

--- a/src/ui/network_table.rs
+++ b/src/ui/network_table.rs
@@ -128,4 +128,67 @@ mod tests {
 
         assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
     }
+
+    #[test]
+    fn error_message_captures_daemon_in_use_segment() {
+        let table = NetworkTable::default();
+        let raw = "Error response from daemon: error while removing network: network foo id \
+            abc123def456 has active endpoints";
+        assert_eq!(
+            table.error_message(raw),
+            "network foo id abc123def456 has active endpoints"
+        );
+
+        assert_eq!(
+            table.error_message("no colons here"),
+            "Something went wrong..."
+        );
+    }
+
+    #[test]
+    fn from_source_strips_fractional_seconds_and_truncates_id() {
+        let mut net = network("abcdef012345extra", "my-net");
+        net.created = Some("2024-01-02T03:04:05.123456789Z".to_string());
+
+        let row = NetworkTableRow::from_source(&net);
+        assert_eq!(row.created_at, "2024-01-02T03:04:05Z");
+        assert_eq!(row.id, "abcdef012345...");
+    }
+
+    #[test]
+    fn handle_resource_key_event_dispatches_remove_network() {
+        let mut table = NetworkTable::default();
+        table.update_with_items(NetworkTableRow::from_list(vec![network(
+            "111111111111",
+            "my-net",
+        )]));
+        table.select_row(0);
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Delete))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveNetwork(name))) => {
+                assert_eq!(name, "my-net")
+            }
+            _ => panic!("expected RemoveNetwork via Delete"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('d')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveNetwork(name))) => {
+                assert_eq!(name, "my-net")
+            }
+            _ => panic!("expected RemoveNetwork via 'd'"),
+        }
+
+        assert!(matches!(
+            table
+                .handle_resource_key_event(KeyEvent::from(KeyCode::Char('z')))
+                .unwrap(),
+            KeyOutcome::Fallthrough
+        ));
+    }
 }

--- a/src/ui/network_table.rs
+++ b/src/ui/network_table.rs
@@ -16,7 +16,7 @@ pub struct NetworkTable {
     info: ResourceTableInfo<NetworkTableRow>,
 }
 
-#[derive(Default)]
+#[derive(Default, PartialEq)]
 pub struct NetworkTableRow {
     id: String,
     name: String,

--- a/src/ui/resource_table.rs
+++ b/src/ui/resource_table.rs
@@ -48,14 +48,14 @@ pub trait ResourceTable {
 
     fn next_row(&mut self) {
         let table_info = self.get_table_info();
-        let last_index = table_info.items.len() - 1;
+        let Some(last_index) = table_info.items.len().checked_sub(1) else { return };
         let next_index = table_info.state.selected().map_or(0, |i| if i >= last_index { 0 } else { i + 1 });
         self.select_row(next_index);
     }
 
     fn previous_row(&mut self) {
         let table_info = self.get_table_info();
-        let last_index = table_info.items.len() - 1;
+        let Some(last_index) = table_info.items.len().checked_sub(1) else { return };
         let previous_index = table_info.state.selected().map_or(0, |i| if i == 0 { last_index } else { i - 1 });
         self.select_row(previous_index);
     }

--- a/src/ui/resource_table.rs
+++ b/src/ui/resource_table.rs
@@ -23,6 +23,7 @@ pub struct ResourceTableInfo<RowType> {
     pub style: TableStyle,
     pub err: Option<String>,
     pub ticker: RefreshTicker,
+    pub pending_ops: usize,
     scrollbar_state: ScrollbarState,
     scroll: usize,
 }
@@ -36,6 +37,7 @@ impl<RowType> Default for ResourceTableInfo<RowType> {
             style: TableStyle::default(),
             err: None,
             ticker: RefreshTicker::default(),
+            pending_ops: 0,
             scrollbar_state: ScrollbarState::default(),
             scroll: 0,
         }
@@ -236,6 +238,10 @@ pub trait ResourceTable {
         let mut text = self.footer_text();
         let mut border = None;
 
+        if self.table_info().pending_ops > 0 {
+            text = format!(" [working]{text}");
+        }
+
         if let Some(err) = &self.table_info().err {
             border = Some(Style::new().red());
             text = err.clone();
@@ -289,6 +295,15 @@ pub trait ResourceTable {
 
     fn show_err(&mut self, err: &DockerError) {
         self.table_info_mut().err = Some(format!("[ERR] {err}"));
+    }
+
+    fn begin_pending_op(&mut self) {
+        self.table_info_mut().pending_ops += 1;
+    }
+
+    fn end_pending_op(&mut self) {
+        let info = self.table_info_mut();
+        info.pending_ops = info.pending_ops.saturating_sub(1);
     }
 }
 
@@ -483,6 +498,34 @@ mod tests {
         table.update_with_items(rows(&[("a", true), ("b", true)]));
         // Items were already non-empty before this update, so selection stays untouched.
         assert_eq!(table.info.state.selected(), None);
+    }
+
+    #[test]
+    fn footer_shows_working_prefix_while_an_op_is_pending() {
+        let mut table = TestTable::default();
+        table.begin_pending_op();
+
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| table.draw(f, f.area()).unwrap()).unwrap();
+
+        let buffer: &Buffer = terminal.backend().buffer();
+        let content: String = buffer.content.iter().map(|c| c.symbol()).collect();
+        assert!(content.contains("[working]"));
+
+        table.info.err = Some("boom".to_string());
+        terminal.draw(|f| table.draw(f, f.area()).unwrap()).unwrap();
+        let buffer: &Buffer = terminal.backend().buffer();
+        let content: String = buffer.content.iter().map(|c| c.symbol()).collect();
+        assert!(content.contains("boom"));
+        assert!(!content.contains("[working]"));
+    }
+
+    #[test]
+    fn end_pending_op_saturates_at_zero() {
+        let mut table = TestTable::default();
+        table.end_pending_op();
+        assert_eq!(table.info.pending_ops, 0);
     }
 
     #[test]

--- a/src/ui/resource_table.rs
+++ b/src/ui/resource_table.rs
@@ -3,17 +3,27 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
-    widgets::{ScrollbarState, TableState},
+    style::{Style, Stylize},
+    text::Text,
+    widgets::{Cell, HighlightSpacing, Row, ScrollbarState, Table, TableState},
 };
 
-use crate::{event::AppEvent, ui::common::render_scrollbar};
+use crate::{
+    event::AppEvent,
+    ui::common::{RefreshTicker, TableStyle, render_scrollbar},
+};
+
+pub const DEFAULT_ROW_HEIGHT: usize = 3;
 
 pub struct ResourceTableInfo<RowType> {
     pub items: Vec<RowType>,
     pub state: TableState,
+    pub row_heights: Vec<usize>,
+    pub style: TableStyle,
+    pub err: Option<String>,
+    pub ticker: RefreshTicker,
     scrollbar_state: ScrollbarState,
     scroll: usize,
-    pub row_heights: Vec<usize>,
 }
 
 impl<RowType> Default for ResourceTableInfo<RowType> {
@@ -21,17 +31,121 @@ impl<RowType> Default for ResourceTableInfo<RowType> {
         Self {
             items: vec![],
             state: TableState::default().with_selected(0),
+            row_heights: vec![],
+            style: TableStyle::default(),
+            err: None,
+            ticker: RefreshTicker::default(),
             scrollbar_state: ScrollbarState::default(),
             scroll: 0,
-            row_heights: vec![],
         }
     }
 }
 
-pub trait ResourceTable {
-    type RowType;
+/// A single row of a `ResourceTable`, projected from a source Docker API type.
+pub trait ResourceRow: Sized {
+    type Source;
 
-    fn get_table_info(&mut self) -> &mut ResourceTableInfo<Self::RowType>;
+    fn from_source(source: &Self::Source) -> Self;
+
+    fn cells(&self) -> Vec<String>;
+
+    fn height(&self) -> usize {
+        DEFAULT_ROW_HEIGHT
+    }
+
+    /// Sorts the rows in place. Default preserves the API's original order.
+    fn sort_rows(_rows: &mut Vec<Self>) {}
+
+    fn from_list(sources: Vec<Self::Source>) -> Vec<Self> {
+        let mut rows = sources.iter().map(Self::from_source).collect::<Vec<Self>>();
+        Self::sort_rows(&mut rows);
+        rows
+    }
+}
+
+/// Outcome of a resource-specific key handler.
+pub enum KeyOutcome {
+    /// The key was consumed; optionally emit an `AppEvent`.
+    Handled(Option<AppEvent>),
+    /// The key was not handled by the resource; fall through to shared navigation handling.
+    Fallthrough,
+}
+
+pub trait ResourceTable {
+    type RowType: ResourceRow;
+
+    const HEADERS: &'static [&'static str];
+    const WIDTHS: &'static [Constraint];
+    const DEFAULT_FOOTER: &'static str;
+
+    fn table_info(&self) -> &ResourceTableInfo<Self::RowType>;
+    fn table_info_mut(&mut self) -> &mut ResourceTableInfo<Self::RowType>;
+
+    fn refresh_event(&self) -> AppEvent;
+    fn handle_resource_key_event(&mut self, key_event: KeyEvent) -> Result<KeyOutcome>;
+    fn error_message(&self, raw: &str) -> String;
+
+    /// Whether the row is currently visible (rendered/navigable). Default: all rows visible.
+    #[allow(unused_variables)]
+    fn is_row_visible(&self, row: &Self::RowType) -> bool {
+        true
+    }
+
+    fn footer_text(&self) -> String {
+        Self::DEFAULT_FOOTER.to_string()
+    }
+
+    fn after_draw(&mut self) {}
+
+    /// Indices into `table_info().items` for the rows that are currently visible.
+    /// Rendering, navigation and selection resolution all share this view.
+    fn visible_indices(&self) -> Vec<usize> {
+        self.table_info()
+            .items
+            .iter()
+            .enumerate()
+            .filter(|(_, row)| self.is_row_visible(row))
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    // The selection index refers to the rendered (filtered) rows, so it must be
+    // resolved and wrapped against the visible list, not `items`.
+    fn selected_row(&self) -> Option<&Self::RowType> {
+        let index = self.table_info().state.selected()?;
+        let item_index = *self.visible_indices().get(index)?;
+        self.table_info().items.get(item_index)
+    }
+
+    fn next_row(&mut self) {
+        let Some(last_index) = self.visible_indices().len().checked_sub(1) else {
+            return;
+        };
+        let next_index = self
+            .table_info()
+            .state
+            .selected()
+            .map_or(0, |i| if i >= last_index { 0 } else { i + 1 });
+        self.select_row(next_index);
+    }
+
+    fn previous_row(&mut self) {
+        let Some(last_index) = self.visible_indices().len().checked_sub(1) else {
+            return;
+        };
+        let previous_index = self
+            .table_info()
+            .state
+            .selected()
+            .map_or(0, |i| if i == 0 { last_index } else { i - 1 });
+        self.select_row(previous_index);
+    }
+
+    fn select_row(&mut self, index: usize) {
+        let table_info = self.table_info_mut();
+        table_info.state.select(Some(index));
+        table_info.scroll = table_info.row_heights.iter().take(index).sum();
+    }
 
     fn handle_nav_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
         let mut event = None;
@@ -46,32 +160,91 @@ pub trait ResourceTable {
         Ok(event)
     }
 
-    fn next_row(&mut self) {
-        let table_info = self.get_table_info();
-        let Some(last_index) = table_info.items.len().checked_sub(1) else { return };
-        let next_index = table_info.state.selected().map_or(0, |i| if i >= last_index { 0 } else { i + 1 });
-        self.select_row(next_index);
+    fn update_scroll_state(&mut self) {
+        let table_info = self.table_info_mut();
+        let content_height: usize = table_info.row_heights.iter().sum();
+        table_info.scrollbar_state = table_info
+            .scrollbar_state
+            .content_length(content_height)
+            .position(table_info.scroll);
     }
 
-    fn previous_row(&mut self) {
-        let table_info = self.get_table_info();
-        let Some(last_index) = table_info.items.len().checked_sub(1) else { return };
-        let previous_index = table_info.state.selected().map_or(0, |i| if i == 0 { last_index } else { i - 1 });
-        self.select_row(previous_index);
+    fn update_with_items(&mut self, items: Vec<Self::RowType>) {
+        let table_info = self.table_info_mut();
+        let is_empty_before_update = table_info.items.is_empty();
+        table_info.items = items;
+
+        if is_empty_before_update && !table_info.items.is_empty() {
+            self.select_row(0);
+        }
     }
 
-    fn get_selected_row(&mut self) -> Option<&Self::RowType> {
-        let table_info = self.get_table_info();
-        table_info.state.selected().and_then(|index| table_info.items.get(index))
+    fn render_table(&mut self, frame: &mut Frame, area: Rect) {
+        let rows: Vec<(usize, Vec<String>)> = self
+            .visible_indices()
+            .iter()
+            .map(|&i| {
+                let row = &self.table_info().items[i];
+                (row.height(), row.cells())
+            })
+            .collect();
+
+        let heights: Vec<usize> = rows
+            .iter()
+            .map(|(h, _)| *h)
+            .take(rows.len().saturating_sub(1))
+            .collect();
+
+        let info = self.table_info_mut();
+        info.row_heights = heights;
+
+        let header = Self::HEADERS
+            .iter()
+            .map(|h| Cell::from(*h))
+            .collect::<Row>()
+            .style(info.style.header_style)
+            .height(1);
+
+        let table_rows = rows
+            .into_iter()
+            .enumerate()
+            .map(|(index, (height, cells))| {
+                let row_style = if index % 2 == 0 {
+                    info.style.row_style
+                } else {
+                    info.style.alt_row_style
+                };
+
+                cells
+                    .into_iter()
+                    .map(|content| Cell::from(Text::from(format!("\n{content}\n"))))
+                    .collect::<Row>()
+                    .style(row_style)
+                    .height(height as u16)
+            });
+
+        let table = Table::new(table_rows, Self::WIDTHS.to_vec())
+            .header(header)
+            .row_highlight_style(info.style.selected_row_style)
+            .highlight_symbol(Text::from(vec!["".into(), " ● ".into()]))
+            .highlight_spacing(HighlightSpacing::Always);
+
+        frame.render_stateful_widget(table, area, &mut info.state);
     }
 
-    fn select_row(&mut self, index: usize) {
-        let table_info = self.get_table_info();
-        table_info.state.select(Some(index));
-        table_info.scroll = table_info.row_heights.iter().take(index).sum();
+    fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
+        let mut text = self.footer_text();
+        let mut border = None;
+
+        if let Some(err) = &self.table_info().err {
+            border = Some(Style::new().red());
+            text = err.clone();
+        }
+
+        crate::ui::common::render_footer(frame, area, text, border);
     }
 
-    fn draw_default(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
         use Constraint::{Length, Min};
 
         let vertical_layout = Layout::vertical([Min(0), Length(3)]);
@@ -84,34 +257,241 @@ pub trait ResourceTable {
 
         self.update_scroll_state();
 
-        let table_info = self.get_table_info();
+        let table_info = self.table_info_mut();
         render_scrollbar(frame, scrollbar_area, &mut table_info.scrollbar_state, true);
 
         self.render_footer(frame, footer_area);
 
+        self.after_draw();
+
         Ok(())
     }
 
-    fn update_scroll_state(&mut self) {
-        let table_info = self.get_table_info();
-        let content_height: usize = table_info.row_heights.iter().sum();
-        table_info.scrollbar_state = table_info.scrollbar_state
-            .content_length(content_height)
-            .position(table_info.scroll);
+    fn tick(&mut self) -> Result<Option<AppEvent>> {
+        if self.table_info_mut().ticker.should_refresh() {
+            Ok(Some(self.refresh_event()))
+        } else {
+            Ok(None)
+        }
     }
 
-    fn render_table(&mut self, frame: &mut Frame, area: Rect);
-
-    #[allow(unused_variables)]
-    fn render_footer(&mut self, frame: &mut Frame, area: Rect) {}
-
-    fn update_with_items(&mut self, items: Vec<Self::RowType>) {
-        let table_info = self.get_table_info();
-        let is_empty_before_update = table_info.items.is_empty();
-        table_info.items = items;
-
-        if is_empty_before_update && !table_info.items.is_empty() {
-            self.select_row(0);
+    fn handle_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
+        if self.table_info().err.is_some() {
+            self.table_info_mut().err = None;
+            return Ok(None);
         }
+
+        match self.handle_resource_key_event(key_event)? {
+            KeyOutcome::Handled(event) => Ok(event),
+            KeyOutcome::Fallthrough => self.handle_nav_key_event(key_event),
+        }
+    }
+
+    fn show_err(&mut self, raw: String) {
+        let msg = self.error_message(&raw);
+        self.table_info_mut().err = Some(format!("[ERR] {}", msg.trim()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
+
+    #[derive(Default, Clone)]
+    struct TestRow {
+        label: String,
+        visible: bool,
+    }
+
+    impl ResourceRow for TestRow {
+        type Source = (String, bool);
+
+        fn from_source(source: &Self::Source) -> Self {
+            Self {
+                label: source.0.clone(),
+                visible: source.1,
+            }
+        }
+
+        fn cells(&self) -> Vec<String> {
+            vec![self.label.clone()]
+        }
+    }
+
+    #[derive(Default)]
+    struct TestTable {
+        info: ResourceTableInfo<TestRow>,
+        filter: bool,
+    }
+
+    impl ResourceTable for TestTable {
+        type RowType = TestRow;
+
+        const HEADERS: &'static [&'static str] = &["Label"];
+        const WIDTHS: &'static [Constraint] = &[Constraint::Min(10)];
+        const DEFAULT_FOOTER: &'static str = " footer";
+
+        fn table_info(&self) -> &ResourceTableInfo<Self::RowType> {
+            &self.info
+        }
+
+        fn table_info_mut(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
+            &mut self.info
+        }
+
+        fn refresh_event(&self) -> AppEvent {
+            AppEvent::UpdateContainers
+        }
+
+        fn handle_resource_key_event(&mut self, key_event: KeyEvent) -> Result<KeyOutcome> {
+            match key_event.code {
+                KeyCode::Char('h') => Ok(KeyOutcome::Handled(None)),
+                _ => Ok(KeyOutcome::Fallthrough),
+            }
+        }
+
+        fn error_message(&self, raw: &str) -> String {
+            raw.to_string()
+        }
+
+        fn is_row_visible(&self, row: &Self::RowType) -> bool {
+            !self.filter || row.visible
+        }
+    }
+
+    fn rows(labels: &[(&str, bool)]) -> Vec<TestRow> {
+        labels
+            .iter()
+            .map(|(l, v)| TestRow {
+                label: (*l).to_string(),
+                visible: *v,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn next_and_previous_row_wrap_around_visible_rows_only() {
+        let mut table = TestTable {
+            filter: true,
+            ..Default::default()
+        };
+        table.update_with_items(rows(&[("a", true), ("b", false), ("c", true)]));
+        // row heights are populated by render normally; set manually for this test.
+        table.info.row_heights = vec![DEFAULT_ROW_HEIGHT, DEFAULT_ROW_HEIGHT];
+
+        table.select_row(0);
+        assert_eq!(
+            table.selected_row().map(|r| r.label.clone()),
+            Some("a".to_string())
+        );
+
+        table.next_row();
+        // Only "a" and "c" are visible, so index 1 resolves to "c".
+        assert_eq!(
+            table.selected_row().map(|r| r.label.clone()),
+            Some("c".to_string())
+        );
+
+        table.next_row();
+        assert_eq!(
+            table.selected_row().map(|r| r.label.clone()),
+            Some("a".to_string())
+        );
+
+        table.previous_row();
+        assert_eq!(
+            table.selected_row().map(|r| r.label.clone()),
+            Some("c".to_string())
+        );
+    }
+
+    #[test]
+    fn select_row_updates_scroll_from_row_heights() {
+        let mut table = TestTable::default();
+        table.update_with_items(rows(&[("a", true), ("b", true), ("c", true)]));
+        table.info.row_heights = vec![3, 5, 7];
+
+        table.select_row(2);
+        assert_eq!(table.info.scroll, 8);
+    }
+
+    #[test]
+    fn handle_key_event_clears_error_without_dispatch() {
+        let mut table = TestTable::default();
+        table.info.err = Some("boom".to_string());
+
+        let result = table
+            .handle_key_event(KeyEvent::from(KeyCode::Char('h')))
+            .unwrap();
+        assert!(result.is_none());
+        assert!(table.info.err.is_none());
+    }
+
+    #[test]
+    fn handled_outcome_does_not_reach_nav_handling() {
+        let mut table = TestTable::default();
+        table.update_with_items(rows(&[("a", true), ("b", true)]));
+        table.info.row_heights = vec![DEFAULT_ROW_HEIGHT];
+        table.select_row(0);
+
+        table
+            .handle_key_event(KeyEvent::from(KeyCode::Char('h')))
+            .unwrap();
+        // 'h' is Handled(None) for TestTable, so selection must not move.
+        assert_eq!(table.info.state.selected(), Some(0));
+    }
+
+    #[test]
+    fn fallthrough_outcome_reaches_nav_handling() {
+        let mut table = TestTable::default();
+        table.update_with_items(rows(&[("a", true), ("b", true)]));
+        table.info.row_heights = vec![DEFAULT_ROW_HEIGHT];
+        table.select_row(0);
+
+        let event = table
+            .handle_key_event(KeyEvent::from(KeyCode::Char('j')))
+            .unwrap();
+        assert!(event.is_none());
+        assert_eq!(table.info.state.selected(), Some(1));
+
+        let event = table
+            .handle_key_event(KeyEvent::from(KeyCode::Char('q')))
+            .unwrap();
+        assert!(matches!(event, Some(AppEvent::Quit)));
+    }
+
+    #[test]
+    fn update_with_items_selects_first_row_only_on_empty_to_nonempty_transition() {
+        let mut table = TestTable::default();
+        table.info.state.select(None);
+
+        table.update_with_items(rows(&[("a", true)]));
+        assert_eq!(table.info.state.selected(), Some(0));
+
+        table.select_row(0);
+        table.info.state.select(None);
+        table.update_with_items(rows(&[("a", true), ("b", true)]));
+        // Items were already non-empty before this update, so selection stays untouched.
+        assert_eq!(table.info.state.selected(), None);
+    }
+
+    #[test]
+    fn draw_renders_headers_and_selection_marker() {
+        let mut table = TestTable::default();
+        table.update_with_items(rows(&[("alpha", true), ("beta", true), ("gamma", true)]));
+        table.select_row(0);
+
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| table.draw(f, f.area()).unwrap()).unwrap();
+
+        let buffer: &Buffer = terminal.backend().buffer();
+        let content: String = buffer.content.iter().map(|c| c.symbol()).collect();
+
+        assert!(content.contains("Label"));
+        assert!(content.contains(" ● "));
+        // 3 visible rows -> last row's height is not recorded.
+        assert_eq!(table.info.row_heights.len(), 2);
     }
 }

--- a/src/ui/resource_table.rs
+++ b/src/ui/resource_table.rs
@@ -9,6 +9,7 @@ use ratatui::{
 };
 
 use crate::{
+    docker::error::DockerError,
     event::AppEvent,
     ui::common::{RefreshTicker, TableStyle, render_scrollbar},
 };
@@ -83,7 +84,6 @@ pub trait ResourceTable {
 
     fn refresh_event(&self) -> AppEvent;
     fn handle_resource_key_event(&mut self, key_event: KeyEvent) -> Result<KeyOutcome>;
-    fn error_message(&self, raw: &str) -> String;
 
     /// Whether the row is currently visible (rendered/navigable). Default: all rows visible.
     #[allow(unused_variables)]
@@ -287,9 +287,8 @@ pub trait ResourceTable {
         }
     }
 
-    fn show_err(&mut self, raw: String) {
-        let msg = self.error_message(&raw);
-        self.table_info_mut().err = Some(format!("[ERR] {}", msg.trim()));
+    fn show_err(&mut self, err: &DockerError) {
+        self.table_info_mut().err = Some(format!("[ERR] {err}"));
     }
 }
 
@@ -349,10 +348,6 @@ mod tests {
                 KeyCode::Char('h') => Ok(KeyOutcome::Handled(None)),
                 _ => Ok(KeyOutcome::Fallthrough),
             }
-        }
-
-        fn error_message(&self, raw: &str) -> String {
-            raw.to_string()
         }
 
         fn is_row_visible(&self, row: &Self::RowType) -> bool {
@@ -426,6 +421,20 @@ mod tests {
             .unwrap();
         assert!(result.is_none());
         assert!(table.info.err.is_none());
+    }
+
+    #[test]
+    fn show_err_formats_typed_error_into_footer() {
+        let mut table = TestTable::default();
+
+        table.show_err(&DockerError::Conflict {
+            message: "network foo has active endpoints".into(),
+        });
+
+        assert_eq!(
+            table.info.err,
+            Some("[ERR] Conflict: network foo has active endpoints".to_string())
+        );
     }
 
     #[test]

--- a/src/ui/resource_table.rs
+++ b/src/ui/resource_table.rs
@@ -45,7 +45,7 @@ impl<RowType> Default for ResourceTableInfo<RowType> {
 }
 
 /// A single row of a `ResourceTable`, projected from a source Docker API type.
-pub trait ResourceRow: Sized {
+pub trait ResourceRow: Sized + PartialEq {
     type Source;
 
     fn from_source(source: &Self::Source) -> Self;
@@ -171,14 +171,18 @@ pub trait ResourceTable {
             .position(table_info.scroll);
     }
 
-    fn update_with_items(&mut self, items: Vec<Self::RowType>) {
+    /// Replaces the rows and reports whether anything visible changed.
+    fn update_with_items(&mut self, items: Vec<Self::RowType>) -> bool {
         let table_info = self.table_info_mut();
+        let changed = table_info.items != items;
         let is_empty_before_update = table_info.items.is_empty();
         table_info.items = items;
 
         if is_empty_before_update && !table_info.items.is_empty() {
             self.select_row(0);
         }
+
+        changed
     }
 
     fn render_table(&mut self, frame: &mut Frame, area: Rect) {
@@ -293,8 +297,13 @@ pub trait ResourceTable {
         }
     }
 
-    fn show_err(&mut self, err: &DockerError) {
-        self.table_info_mut().err = Some(format!("[ERR] {err}"));
+    /// Sets the footer error message and reports whether it differs from the
+    /// previously shown error.
+    fn show_err(&mut self, err: &DockerError) -> bool {
+        let message = format!("[ERR] {err}");
+        let changed = self.table_info().err.as_deref() != Some(message.as_str());
+        self.table_info_mut().err = Some(message);
+        changed
     }
 
     fn begin_pending_op(&mut self) {
@@ -312,7 +321,7 @@ mod tests {
     use super::*;
     use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
 
-    #[derive(Default, Clone)]
+    #[derive(Default, Clone, PartialEq)]
     struct TestRow {
         label: String,
         visible: bool,
@@ -442,7 +451,7 @@ mod tests {
     fn show_err_formats_typed_error_into_footer() {
         let mut table = TestTable::default();
 
-        table.show_err(&DockerError::Conflict {
+        let changed = table.show_err(&DockerError::Conflict {
             message: "network foo has active endpoints".into(),
         });
 
@@ -450,6 +459,26 @@ mod tests {
             table.info.err,
             Some("[ERR] Conflict: network foo has active endpoints".to_string())
         );
+        assert!(changed);
+
+        let changed_again = table.show_err(&DockerError::Conflict {
+            message: "network foo has active endpoints".into(),
+        });
+        assert!(!changed_again);
+    }
+
+    #[test]
+    fn update_with_items_reports_change_only_when_rows_differ() {
+        let mut table = TestTable::default();
+
+        let changed = table.update_with_items(rows(&[("a", true), ("b", true)]));
+        assert!(changed);
+
+        let changed_again = table.update_with_items(rows(&[("a", true), ("b", true)]));
+        assert!(!changed_again);
+
+        let changed_different = table.update_with_items(rows(&[("a", true), ("c", true)]));
+        assert!(changed_different);
     }
 
     #[test]

--- a/src/ui/volume_table.rs
+++ b/src/ui/volume_table.rs
@@ -127,7 +127,10 @@ impl VolumeTable {
         let err_msg = Regex::new(REGEX_VOLUME_IN_USE).ok()
             .and_then(|re| re.captures(&err))
             .and_then(|caps| caps.get(1))
-            .map(|m| format!("Volume is in use by container: {}...", &m.as_str()[..15]))
+            .map(|m| {
+                let id = m.as_str();
+                format!("Volume is in use by container: {}...", id.get(..15).unwrap_or(id))
+            })
             .unwrap_or_else(|| "Something went wrong...".to_string());
 
         self.err = Some(format!("[ERR] {}", err_msg))

--- a/src/ui/volume_table.rs
+++ b/src/ui/volume_table.rs
@@ -2,14 +2,11 @@ use bollard::secret::Volume;
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::layout::Constraint;
-use regex::Regex;
 
 use crate::{
     event::AppEvent,
     ui::resource_table::{KeyOutcome, ResourceRow, ResourceTable, ResourceTableInfo},
 };
-
-const REGEX_VOLUME_IN_USE: &str = r"\[([a-z0-9]+)\]";
 
 #[derive(Default)]
 pub struct VolumeTable {
@@ -61,21 +58,6 @@ impl ResourceTable for VolumeTable {
 
         Ok(outcome)
     }
-
-    fn error_message(&self, raw: &str) -> String {
-        Regex::new(REGEX_VOLUME_IN_USE)
-            .ok()
-            .and_then(|re| re.captures(raw))
-            .and_then(|caps| caps.get(1))
-            .map(|m| {
-                let id = m.as_str();
-                format!(
-                    "Volume is in use by container: {}...",
-                    id.get(..15).unwrap_or(id)
-                )
-            })
-            .unwrap_or_else(|| "Something went wrong...".to_string())
-    }
 }
 
 impl ResourceRow for VolumeTableRow {
@@ -121,29 +103,6 @@ mod tests {
         let names: Vec<String> = rows.iter().map(|r| r.name.clone()).collect();
 
         assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
-    }
-
-    #[test]
-    fn error_message_truncates_long_container_id_to_fifteen_chars() {
-        let table = VolumeTable::default();
-        let msg = table.error_message("volume is in use by container [abcdef0123456789abc]");
-        assert_eq!(msg, "Volume is in use by container: abcdef012345678...");
-    }
-
-    #[test]
-    fn error_message_leaves_short_container_id_untruncated() {
-        let table = VolumeTable::default();
-        let msg = table.error_message("volume is in use by container [abc123]");
-        assert_eq!(msg, "Volume is in use by container: abc123...");
-    }
-
-    #[test]
-    fn error_message_falls_back_when_no_bracketed_id() {
-        let table = VolumeTable::default();
-        assert_eq!(
-            table.error_message("some unrelated error"),
-            "Something went wrong..."
-        );
     }
 
     #[test]

--- a/src/ui/volume_table.rs
+++ b/src/ui/volume_table.rs
@@ -122,4 +122,54 @@ mod tests {
 
         assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
     }
+
+    #[test]
+    fn error_message_truncates_long_container_id_to_fifteen_chars() {
+        let table = VolumeTable::default();
+        let msg = table.error_message("volume is in use by container [abcdef0123456789abc]");
+        assert_eq!(msg, "Volume is in use by container: abcdef012345678...");
+    }
+
+    #[test]
+    fn error_message_leaves_short_container_id_untruncated() {
+        let table = VolumeTable::default();
+        let msg = table.error_message("volume is in use by container [abc123]");
+        assert_eq!(msg, "Volume is in use by container: abc123...");
+    }
+
+    #[test]
+    fn error_message_falls_back_when_no_bracketed_id() {
+        let table = VolumeTable::default();
+        assert_eq!(
+            table.error_message("some unrelated error"),
+            "Something went wrong..."
+        );
+    }
+
+    #[test]
+    fn handle_resource_key_event_dispatches_expected_events() {
+        let mut table = VolumeTable::default();
+        table.update_with_items(VolumeTableRow::from_list(vec![volume("my-volume")]));
+        table.select_row(0);
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('d')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveVolume(name, false))) => {
+                assert_eq!(name, "my-volume")
+            }
+            _ => panic!("expected RemoveVolume(name, false)"),
+        }
+
+        match table
+            .handle_resource_key_event(KeyEvent::from(KeyCode::Char('f')))
+            .unwrap()
+        {
+            KeyOutcome::Handled(Some(AppEvent::RemoveVolume(name, true))) => {
+                assert_eq!(name, "my-volume")
+            }
+            _ => panic!("expected RemoveVolume(name, true)"),
+        }
+    }
 }

--- a/src/ui/volume_table.rs
+++ b/src/ui/volume_table.rs
@@ -1,26 +1,19 @@
 use bollard::secret::Volume;
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
-use ratatui::{
-    layout::{Constraint, Rect}, style::{Style, Stylize}, text::Text, widgets::{Cell, HighlightSpacing, Row, Table}, Frame
-};
+use ratatui::layout::Constraint;
 use regex::Regex;
 
 use crate::{
-    event::AppEvent, ui::{common::{render_footer, TableStyle}, resource_table::{ResourceTable, ResourceTableInfo}}
+    event::AppEvent,
+    ui::resource_table::{KeyOutcome, ResourceRow, ResourceTable, ResourceTableInfo},
 };
 
-const ROW_HEIGHT: usize = 3;
-const REFRESH_AFTER_TICK: u8 = 10;
 const REGEX_VOLUME_IN_USE: &str = r"\[([a-z0-9]+)\]";
-const DEFAULT_FOOTER: &str = " <Del/D> remove | <F> force remove";
 
 #[derive(Default)]
 pub struct VolumeTable {
-    style: TableStyle,
-    skipped_tick_count_for_refresh: u8,
     info: ResourceTableInfo<VolumeTableRow>,
-    err: Option<String>,
 }
 
 #[derive(Default)]
@@ -33,126 +26,100 @@ pub struct VolumeTableRow {
 impl ResourceTable for VolumeTable {
     type RowType = VolumeTableRow;
 
-    fn get_table_info(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
+    const HEADERS: &'static [&'static str] = &["Name", "Driver", "Created At"];
+    const WIDTHS: &'static [Constraint] = &[
+        Constraint::Min(30),
+        Constraint::Min(0),
+        Constraint::Length(27),
+    ];
+    const DEFAULT_FOOTER: &'static str = " <Del/D> remove | <F> force remove";
+
+    fn table_info(&self) -> &ResourceTableInfo<Self::RowType> {
+        &self.info
+    }
+
+    fn table_info_mut(&mut self) -> &mut ResourceTableInfo<Self::RowType> {
         &mut self.info
     }
 
-    fn render_table(&mut self, frame: &mut Frame, area: Rect) {
-        let header = ["Name", "Driver", "Created At"].into_iter()
-            .map(Cell::from)
-            .collect::<Row>()
-            .style(self.style.header_style)
-            .height(1);
-
-        self.info.row_heights.clear();
-
-        let rows = self.info.items.iter().enumerate().map(|(index, volume)| {
-            let row_style = if index % 2 == 0 { self.style.row_style } else { self.style.alt_row_style };
-            let item = volume.ref_array();
-
-            if index < self.info.items.len() - 1 {
-                self.info.row_heights.push(ROW_HEIGHT);
-            }
-
-            item.into_iter()
-                .map(|content| Cell::from(Text::from(format!("\n{content}\n"))))
-                .collect::<Row>()
-                .style(row_style)
-                .height(ROW_HEIGHT as u16)
-        });
-
-        let widths = vec![
-            Constraint::Min(30),
-            Constraint::Min(0),
-            Constraint::Length(27),
-        ];
-
-        let table = Table::new(rows, widths)
-            .header(header)
-            .row_highlight_style(self.style.selected_row_style)
-            .highlight_symbol(Text::from(vec!["".into(), " ● ".into()]))
-            .highlight_spacing(HighlightSpacing::Always);
-
-        frame.render_stateful_widget(table, area, &mut self.info.state);
+    fn refresh_event(&self) -> AppEvent {
+        AppEvent::UpdateVolumes
     }
 
-    fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
-        let mut border_style = None;
-        let mut footer_text = DEFAULT_FOOTER.to_string();
-
-        if let Some(err) = &self.err {
-            border_style = Some(Style::new().red());
-            footer_text = err.clone();
-        }
-
-        render_footer(frame, area, footer_text, border_style);
-    }
-}
-
-impl VolumeTable {
-    pub fn handle_key_event(&mut self, key_event: KeyEvent) -> Result<Option<AppEvent>> {
-        if self.err.is_some() {
-            self.err = None;
-            return Ok(None);
-        }
-
-        let event = match key_event.code {
-            KeyCode::Delete | KeyCode::Char('d') => {
-                self.get_selected_row().map(|volume| AppEvent::RemoveVolume(volume.name.clone(), false))
-            }
-            KeyCode::Char('f') => {
-                self.get_selected_row().map(|volume| AppEvent::RemoveVolume(volume.name.clone(), true))
-            }
-            _ => self.handle_nav_key_event(key_event)?
+    fn handle_resource_key_event(&mut self, key_event: KeyEvent) -> Result<KeyOutcome> {
+        let outcome = match key_event.code {
+            KeyCode::Delete | KeyCode::Char('d') => KeyOutcome::Handled(
+                self.selected_row()
+                    .map(|v| AppEvent::RemoveVolume(v.name.clone(), false)),
+            ),
+            KeyCode::Char('f') => KeyOutcome::Handled(
+                self.selected_row()
+                    .map(|v| AppEvent::RemoveVolume(v.name.clone(), true)),
+            ),
+            _ => KeyOutcome::Fallthrough,
         };
 
-        Ok(event)
+        Ok(outcome)
     }
 
-    pub fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        self.draw_default(frame, area)
-    }
-
-    pub fn tick(&mut self) -> Result<Option<AppEvent>> {
-        if self.skipped_tick_count_for_refresh <= REFRESH_AFTER_TICK {
-            self.skipped_tick_count_for_refresh += 1;
-            return Ok(None);
-        }
-
-        self.skipped_tick_count_for_refresh = 0;
-        Ok(Some(AppEvent::UpdateVolumes))
-    }
-
-    pub fn show_remove_volume_err(&mut self, err: String) {
-        let err_msg = Regex::new(REGEX_VOLUME_IN_USE).ok()
-            .and_then(|re| re.captures(&err))
+    fn error_message(&self, raw: &str) -> String {
+        Regex::new(REGEX_VOLUME_IN_USE)
+            .ok()
+            .and_then(|re| re.captures(raw))
             .and_then(|caps| caps.get(1))
             .map(|m| {
                 let id = m.as_str();
-                format!("Volume is in use by container: {}...", id.get(..15).unwrap_or(id))
+                format!(
+                    "Volume is in use by container: {}...",
+                    id.get(..15).unwrap_or(id)
+                )
             })
-            .unwrap_or_else(|| "Something went wrong...".to_string());
-
-        self.err = Some(format!("[ERR] {}", err_msg))
+            .unwrap_or_else(|| "Something went wrong...".to_string())
     }
 }
 
-impl VolumeTableRow {
-    const fn ref_array(&self) -> [&String; 3] {
-        [&self.name, &self.driver, &self.created_at]
-    }
+impl ResourceRow for VolumeTableRow {
+    type Source = Volume;
 
-    pub fn from_list(volumes: Vec<Volume>) -> Vec<Self> {
-        let mut result = volumes.iter().map(Self::from).collect::<Vec<Self>>();
-        result.sort_by_key(|v| v.name.clone());
-        result
-    }
-
-    fn from(volume: &Volume) -> Self {
+    fn from_source(volume: &Self::Source) -> Self {
         Self {
             name: volume.name.clone(),
             driver: volume.driver.clone(),
             created_at: volume.created_at.as_deref().unwrap_or_default().to_string(),
         }
+    }
+
+    fn cells(&self) -> Vec<String> {
+        vec![
+            self.name.clone(),
+            self.driver.clone(),
+            self.created_at.clone(),
+        ]
+    }
+
+    fn sort_rows(rows: &mut Vec<Self>) {
+        rows.sort_by_key(|v| v.name.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn volume(name: &str) -> Volume {
+        Volume {
+            name: name.to_string(),
+            driver: "local".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn from_list_sorts_by_name() {
+        let volumes = vec![volume("charlie"), volume("alpha"), volume("bravo")];
+        let rows = VolumeTableRow::from_list(volumes);
+        let names: Vec<String> = rows.iter().map(|r| r.name.clone()).collect();
+
+        assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
     }
 }

--- a/src/ui/volume_table.rs
+++ b/src/ui/volume_table.rs
@@ -2,7 +2,7 @@ use bollard::secret::Volume;
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
-    layout::{Constraint, Rect}, style::{Style, Stylize}, text::Text, widgets::{Cell, HighlightSpacing, Row, Table}, Frame
+    layout::{Constraint, Rect}, style::Style, text::Text, widgets::{Cell, HighlightSpacing, Row, Table}, Frame
 };
 use regex::Regex;
 

--- a/src/ui/volume_table.rs
+++ b/src/ui/volume_table.rs
@@ -13,7 +13,7 @@ pub struct VolumeTable {
     info: ResourceTableInfo<VolumeTableRow>,
 }
 
-#[derive(Default)]
+#[derive(Default, PartialEq)]
 pub struct VolumeTableRow {
     name: String,
     driver: String,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,17 @@
-pub fn is_container_running(state: &str) -> bool {
-    state == "running"
+use bollard::secret::ContainerStateStatusEnum;
+
+pub fn is_container_running(state: ContainerStateStatusEnum) -> bool {
+    state == ContainerStateStatusEnum::RUNNING
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_container_running_only_true_for_running() {
+        assert!(is_container_running(ContainerStateStatusEnum::RUNNING));
+        assert!(!is_container_running(ContainerStateStatusEnum::RESTARTING));
+        assert!(!is_container_running(ContainerStateStatusEnum::REMOVING));
+    }
 }


### PR DESCRIPTION
## Release v0.3.0

Everything merged into `dev` since `v0.2.1`. Version bump lands via #44 before this merges.

### Features
- Run Docker operations as background tasks so the UI stays responsive (#38)

### Fixes
- Let Esc and arrow keys fall through on the containers tab (#43)
- Keep image and container row order stable across refreshes (#39)
- Route all Docker errors through a typed `DockerError` and show them in the footer (#37)
- Resolve selection against filtered rows in the container table (#29)
- Prevent underflow panic when navigating an empty table (#26)
- Avoid slice panic in volume-in-use error for short container IDs (#27)
- Resolve `collapsible_if` clippy errors (#28)

### Performance
- Redraw only on state change and cache container detail lines (#41)

### Refactoring
- Replace stringly-typed container data with typed domain models (#30)
- Deduplicate resource table implementations into a shared trait skeleton (#33)
- Introduce `DockerApi` trait to make `App` testable without a daemon (#34)

### Tests & CI
- Unit tests for UI formatting, sorting, key handling, and App event handling with a mock Docker client (#34)
- CI runs fmt, clippy, build, and test on push and PRs (#34, #36)

### Docs & chores
- Branching model, contribution guide, and English-only rule (#25)
- Issue/PR label and linking workflow (#40)
- Resolve open Dependabot alerts (#32)
- Bump version to 0.3.0 (#44)

## Test plan
- [ ] CI green on this PR (fmt, clippy, build, test)
- [ ] `cargo run` against a local Docker daemon: containers/images/volumes tabs render, navigation and Esc behave, Docker ops stay responsive
- [ ] After merge: tag `v0.3.0` on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)